### PR TITLE
fix(api): use port from env for Zeabur deployment

### DIFF
--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -33,8 +33,12 @@ func Execute() {
 	r := gin.Default()
 	api.Register(r, a)
 
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
 	srv := &http.Server{
-		Addr:              ":8080",
+		Addr:              ":" + port,
 		Handler:           r,
 		ReadHeaderTimeout: 5 * time.Second,
 	}


### PR DESCRIPTION
<!-- 請先閱讀我們手冊的 [How to PR](https://hackmd.io/@sessatakuma/pr_template#How-to-PR) 章節 -->
<!-- 記得修改PR標題成 conventional commit 之標題格式  -->

### 目的
Use port from env for Zeabur deployment.