### PR TITLE
fix(swagger): align api-tools proxy schemas with actual responses

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -2949,7 +2949,8 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.DictQueryWordResult"
-                    }
+                    },
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3109,7 +3110,8 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.WordAccentResult"
-                    }
+                    },
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3131,7 +3133,8 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.WordAccentResult"
-                    }
+                    },
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3172,7 +3175,12 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "result": {
-                    "$ref": "#/definitions/internal_api.SentenceQueryWordResult"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/internal_api.SentenceQueryWordResult"
+                        }
+                    ],
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3222,7 +3230,8 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.HeadWord"
-                    }
+                    },
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3250,7 +3259,12 @@ const docTemplate = `{
                     "$ref": "#/definitions/internal_api.APIToolsError"
                 },
                 "result": {
-                    "$ref": "#/definitions/internal_api.IdDetails"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/internal_api.IdDetails"
+                        }
+                    ],
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3268,7 +3282,8 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.UsageQueryWordURL"
-                    }
+                    },
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -17,7 +17,7 @@ const docTemplate = `{
     "paths": {
         "/v1/dict-query": {
             "post": {
-                "description": "Look up words in JMdict (Japanese-Multilingual Dictionary). Returns kanji forms, furigana readings, parts of speech, and English definitions. Supports searching by kanji, kana, or romaji.",
+                "description": "Look up words in JMdict (Japanese-Multilingual Dictionary). Returns kanji forms, furigana readings, parts of speech, and English definitions. Supports searching by kanji, kana, or romaji. Body convention: the inner ` + "`" + `status` + "`" + ` carries the real result code; ` + "`" + `error` + "`" + ` is ` + "`" + `null` + "`" + ` on success and populated only when ` + "`" + `status != 200` + "`" + `.",
                 "consumes": [
                     "application/json"
                 ],
@@ -49,10 +49,7 @@ const docTemplate = `{
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -1115,7 +1112,7 @@ const docTemplate = `{
         },
         "/v1/mark-accent": {
             "post": {
-                "description": "Analyze Japanese text and return per-mora pitch (accent) patterns for each word. ` + "`" + `accent_marking_type` + "`" + ` values: 0=low/unknown, 1=heiban (high plateau), 2=fall kernel. Optional flags control whether English-letter and katakana tokens carry furigana, and ` + "`" + `script` + "`" + ` rewrites every furigana field to hiragana, katakana, or romaji.",
+                "description": "Analyze Japanese text and return per-mora pitch (accent) patterns for each word. ` + "`" + `accent_marking_type` + "`" + ` values: 0=low/unknown, 1=heiban (high plateau), 2=fall kernel. Optional flags control whether English-letter and katakana tokens carry furigana, and ` + "`" + `script` + "`" + ` rewrites every furigana field to hiragana, katakana, or romaji. Body convention: the inner ` + "`" + `status` + "`" + ` carries the real result code; ` + "`" + `error` + "`" + ` is ` + "`" + `null` + "`" + ` on success and populated only when ` + "`" + `status != 200` + "`" + `.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1147,10 +1144,7 @@ const docTemplate = `{
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -1163,7 +1157,7 @@ const docTemplate = `{
         },
         "/v1/mark-accent/stream": {
             "post": {
-                "description": "Same input and per-chunk output as /v1/mark-accent, but streamed as NDJSON: one JSON object per line, emitted as soon as each input chunk finishes. Each line carries ` + "`" + `{\"chunk\": \u003cline_idx\u003e, \"subchunk\": \u003csub_idx\u003e, ...AccentResponse}` + "`" + ` so clients can interleave UI rendering with later chunks still in flight.",
+                "description": "Same input and per-chunk output as /v1/mark-accent, but streamed as NDJSON: one JSON object per line, emitted as soon as each input chunk finishes. Each line carries ` + "`" + `{\"chunk\": \u003cline_idx\u003e, \"subchunk\": \u003csub_idx\u003e, ...AccentResponse}` + "`" + ` so clients can interleave UI rendering with later chunks still in flight. Body convention: each chunk's inner ` + "`" + `status` + "`" + ` carries the real result code; ` + "`" + `error` + "`" + ` is ` + "`" + `null` + "`" + ` on success and populated only when ` + "`" + `status != 200` + "`" + `.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1187,18 +1181,15 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "NDJSON stream of per-chunk AccentResponse objects",
+                        "description": "One NDJSON line per chunk; full response is a stream of these objects separated by '\\\\n'",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/internal_api.MarkAccentStreamChunk"
                         }
                     },
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -1930,7 +1921,7 @@ const docTemplate = `{
         },
         "/v1/sentence-query": {
             "post": {
-                "description": "Find example sentences containing a given word from JMdict. Requires both the word and its JMdict entry ID (obtained from the dict-query endpoint). Returns bilingual Japanese-English sentence pairs.",
+                "description": "Find example sentences containing a given word from JMdict. Requires both the word and its JMdict entry ID (obtained from the dict-query endpoint). Returns bilingual Japanese-English sentence pairs. Body convention: the inner ` + "`" + `status` + "`" + ` carries the real result code; ` + "`" + `error` + "`" + ` is an empty string on success and populated only when ` + "`" + `status != 200` + "`" + `.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1962,10 +1953,7 @@ const docTemplate = `{
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -2366,7 +2354,7 @@ const docTemplate = `{
         },
         "/v1/usage-query/headwords": {
             "post": {
-                "description": "Search for headwords in Japanese language corpora. Supports lookup by kanji, kana, or romaji. Returns matching headword entries with readings and frequency data. Specify site as NLB (NINJAL LRP BCCWJ) or NLT (Tsukuba Web Corpus).",
+                "description": "Search for headwords in Japanese language corpora. Supports lookup by kanji, kana, or romaji. Returns matching headword entries with readings and frequency data. Specify site as NLB (NINJAL LRP BCCWJ) or NLT (Tsukuba Web Corpus). Body convention: the inner ` + "`" + `status` + "`" + ` carries the real result code; ` + "`" + `error` + "`" + ` is ` + "`" + `null` + "`" + ` on success and populated only when ` + "`" + `status != 200` + "`" + `.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2398,10 +2386,7 @@ const docTemplate = `{
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -2414,7 +2399,7 @@ const docTemplate = `{
         },
         "/v1/usage-query/id-details": {
             "post": {
-                "description": "Retrieve detailed usage information for a specific headword by its ID. Returns base form, subcorpus distribution, conjugation patterns (shojikei/katuyokei), and collocation data. The headword_id must be obtained from the headwords endpoint first.",
+                "description": "Retrieve detailed usage information for a specific headword by its ID. Returns base form, subcorpus distribution, conjugation patterns (shojikei/katuyokei), and collocation data. The headword_id must be obtained from the headwords endpoint first. Body convention: the inner ` + "`" + `status` + "`" + ` carries the real result code; ` + "`" + `error` + "`" + ` is ` + "`" + `null` + "`" + ` on success and populated only when ` + "`" + `status != 200` + "`" + `.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2446,10 +2431,7 @@ const docTemplate = `{
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -2462,7 +2444,7 @@ const docTemplate = `{
         },
         "/v1/usage-query/url": {
             "post": {
-                "description": "Given a word, return URLs to the corresponding headword detail pages in the selected corpus (NLB or NLT). Uses the same request format as the headwords endpoint.",
+                "description": "Given a word, return URLs to the corresponding headword detail pages in the selected corpus (NLB or NLT). Uses the same request format as the headwords endpoint. Body convention: the inner ` + "`" + `status` + "`" + ` carries the real result code; ` + "`" + `error` + "`" + ` is ` + "`" + `null` + "`" + ` on success and populated only when ` + "`" + `status != 200` + "`" + `.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2494,10 +2476,7 @@ const docTemplate = `{
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -2903,11 +2882,11 @@ const docTemplate = `{
             "properties": {
                 "code": {
                     "type": "integer",
-                    "example": 500
+                    "example": 0
                 },
                 "message": {
                     "type": "string",
-                    "example": "HTTP error 500"
+                    "example": " "
                 }
             }
         },
@@ -3138,6 +3117,41 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_api.MarkAccentStreamChunk": {
+            "type": "object",
+            "properties": {
+                "chunk": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "error": {
+                    "$ref": "#/definitions/internal_api.APIToolsError"
+                },
+                "result": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api.WordAccentResult"
+                    }
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
+                },
+                "subchunk": {
+                    "type": "integer",
+                    "example": 0
+                }
+            }
+        },
+        "internal_api.ProxyErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to contact external API"
+                }
+            }
+        },
         "internal_api.SentenceQueryRequest": {
             "type": "object",
             "properties": {
@@ -3329,12 +3343,6 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "type": "integer"
-                    }
-                },
-                "subword": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_api.WordAccentSubword"
                     }
                 },
                 "surface": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -11,7 +11,7 @@
     "paths": {
         "/v1/dict-query": {
             "post": {
-                "description": "Look up words in JMdict (Japanese-Multilingual Dictionary). Returns kanji forms, furigana readings, parts of speech, and English definitions. Supports searching by kanji, kana, or romaji.",
+                "description": "Look up words in JMdict (Japanese-Multilingual Dictionary). Returns kanji forms, furigana readings, parts of speech, and English definitions. Supports searching by kanji, kana, or romaji. Body convention: the inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.",
                 "consumes": [
                     "application/json"
                 ],
@@ -43,10 +43,7 @@
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -1109,7 +1106,7 @@
         },
         "/v1/mark-accent": {
             "post": {
-                "description": "Analyze Japanese text and return per-mora pitch (accent) patterns for each word. `accent_marking_type` values: 0=low/unknown, 1=heiban (high plateau), 2=fall kernel. Optional flags control whether English-letter and katakana tokens carry furigana, and `script` rewrites every furigana field to hiragana, katakana, or romaji.",
+                "description": "Analyze Japanese text and return per-mora pitch (accent) patterns for each word. `accent_marking_type` values: 0=low/unknown, 1=heiban (high plateau), 2=fall kernel. Optional flags control whether English-letter and katakana tokens carry furigana, and `script` rewrites every furigana field to hiragana, katakana, or romaji. Body convention: the inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1141,10 +1138,7 @@
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -1157,7 +1151,7 @@
         },
         "/v1/mark-accent/stream": {
             "post": {
-                "description": "Same input and per-chunk output as /v1/mark-accent, but streamed as NDJSON: one JSON object per line, emitted as soon as each input chunk finishes. Each line carries `{\"chunk\": \u003cline_idx\u003e, \"subchunk\": \u003csub_idx\u003e, ...AccentResponse}` so clients can interleave UI rendering with later chunks still in flight.",
+                "description": "Same input and per-chunk output as /v1/mark-accent, but streamed as NDJSON: one JSON object per line, emitted as soon as each input chunk finishes. Each line carries `{\"chunk\": \u003cline_idx\u003e, \"subchunk\": \u003csub_idx\u003e, ...AccentResponse}` so clients can interleave UI rendering with later chunks still in flight. Body convention: each chunk's inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1181,18 +1175,15 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "NDJSON stream of per-chunk AccentResponse objects",
+                        "description": "One NDJSON line per chunk; full response is a stream of these objects separated by '\\\\n'",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/internal_api.MarkAccentStreamChunk"
                         }
                     },
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -1924,7 +1915,7 @@
         },
         "/v1/sentence-query": {
             "post": {
-                "description": "Find example sentences containing a given word from JMdict. Requires both the word and its JMdict entry ID (obtained from the dict-query endpoint). Returns bilingual Japanese-English sentence pairs.",
+                "description": "Find example sentences containing a given word from JMdict. Requires both the word and its JMdict entry ID (obtained from the dict-query endpoint). Returns bilingual Japanese-English sentence pairs. Body convention: the inner `status` carries the real result code; `error` is an empty string on success and populated only when `status != 200`.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1956,10 +1947,7 @@
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -2360,7 +2348,7 @@
         },
         "/v1/usage-query/headwords": {
             "post": {
-                "description": "Search for headwords in Japanese language corpora. Supports lookup by kanji, kana, or romaji. Returns matching headword entries with readings and frequency data. Specify site as NLB (NINJAL LRP BCCWJ) or NLT (Tsukuba Web Corpus).",
+                "description": "Search for headwords in Japanese language corpora. Supports lookup by kanji, kana, or romaji. Returns matching headword entries with readings and frequency data. Specify site as NLB (NINJAL LRP BCCWJ) or NLT (Tsukuba Web Corpus). Body convention: the inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2392,10 +2380,7 @@
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -2408,7 +2393,7 @@
         },
         "/v1/usage-query/id-details": {
             "post": {
-                "description": "Retrieve detailed usage information for a specific headword by its ID. Returns base form, subcorpus distribution, conjugation patterns (shojikei/katuyokei), and collocation data. The headword_id must be obtained from the headwords endpoint first.",
+                "description": "Retrieve detailed usage information for a specific headword by its ID. Returns base form, subcorpus distribution, conjugation patterns (shojikei/katuyokei), and collocation data. The headword_id must be obtained from the headwords endpoint first. Body convention: the inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2440,10 +2425,7 @@
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -2456,7 +2438,7 @@
         },
         "/v1/usage-query/url": {
             "post": {
-                "description": "Given a word, return URLs to the corresponding headword detail pages in the selected corpus (NLB or NLT). Uses the same request format as the headwords endpoint.",
+                "description": "Given a word, return URLs to the corresponding headword detail pages in the selected corpus (NLB or NLT). Uses the same request format as the headwords endpoint. Body convention: the inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2488,10 +2470,7 @@
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/internal_api.ProxyErrorResponse"
                         }
                     }
                 },
@@ -2897,11 +2876,11 @@
             "properties": {
                 "code": {
                     "type": "integer",
-                    "example": 500
+                    "example": 0
                 },
                 "message": {
                     "type": "string",
-                    "example": "HTTP error 500"
+                    "example": " "
                 }
             }
         },
@@ -3132,6 +3111,41 @@
                 }
             }
         },
+        "internal_api.MarkAccentStreamChunk": {
+            "type": "object",
+            "properties": {
+                "chunk": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "error": {
+                    "$ref": "#/definitions/internal_api.APIToolsError"
+                },
+                "result": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api.WordAccentResult"
+                    }
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
+                },
+                "subchunk": {
+                    "type": "integer",
+                    "example": 0
+                }
+            }
+        },
+        "internal_api.ProxyErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "Failed to contact external API"
+                }
+            }
+        },
         "internal_api.SentenceQueryRequest": {
             "type": "object",
             "properties": {
@@ -3323,12 +3337,6 @@
                     "type": "array",
                     "items": {
                         "type": "integer"
-                    }
-                },
-                "subword": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_api.WordAccentSubword"
                     }
                 },
                 "surface": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -2943,7 +2943,8 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.DictQueryWordResult"
-                    }
+                    },
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3103,7 +3104,8 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.WordAccentResult"
-                    }
+                    },
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3125,7 +3127,8 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.WordAccentResult"
-                    }
+                    },
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3166,7 +3169,12 @@
                     "type": "string"
                 },
                 "result": {
-                    "$ref": "#/definitions/internal_api.SentenceQueryWordResult"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/internal_api.SentenceQueryWordResult"
+                        }
+                    ],
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3216,7 +3224,8 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.HeadWord"
-                    }
+                    },
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3244,7 +3253,12 @@
                     "$ref": "#/definitions/internal_api.APIToolsError"
                 },
                 "result": {
-                    "$ref": "#/definitions/internal_api.IdDetails"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/internal_api.IdDetails"
+                        }
+                    ],
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",
@@ -3262,7 +3276,8 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.UsageQueryWordURL"
-                    }
+                    },
+                    "x-nullable": "true"
                 },
                 "status": {
                     "type": "integer",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -58,6 +58,7 @@ definitions:
         items:
           $ref: '#/definitions/internal_api.DictQueryWordResult'
         type: array
+        x-nullable: "true"
       status:
         example: 200
         type: integer
@@ -170,6 +171,7 @@ definitions:
         items:
           $ref: '#/definitions/internal_api.WordAccentResult'
         type: array
+        x-nullable: "true"
       status:
         example: 200
         type: integer
@@ -185,6 +187,7 @@ definitions:
         items:
           $ref: '#/definitions/internal_api.WordAccentResult'
         type: array
+        x-nullable: "true"
       status:
         example: 200
         type: integer
@@ -212,7 +215,9 @@ definitions:
       error:
         type: string
       result:
-        $ref: '#/definitions/internal_api.SentenceQueryWordResult'
+        allOf:
+        - $ref: '#/definitions/internal_api.SentenceQueryWordResult'
+        x-nullable: "true"
       status:
         example: 200
         type: integer
@@ -247,6 +252,7 @@ definitions:
         items:
           $ref: '#/definitions/internal_api.HeadWord'
         type: array
+        x-nullable: "true"
       status:
         example: 200
         type: integer
@@ -265,7 +271,9 @@ definitions:
       error:
         $ref: '#/definitions/internal_api.APIToolsError'
       result:
-        $ref: '#/definitions/internal_api.IdDetails'
+        allOf:
+        - $ref: '#/definitions/internal_api.IdDetails'
+        x-nullable: "true"
       status:
         example: 200
         type: integer
@@ -278,6 +286,7 @@ definitions:
         items:
           $ref: '#/definitions/internal_api.UsageQueryWordURL'
         type: array
+        x-nullable: "true"
       status:
         example: 200
         type: integer

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -11,10 +11,10 @@ definitions:
   internal_api.APIToolsError:
     properties:
       code:
-        example: 500
+        example: 0
         type: integer
       message:
-        example: HTTP error 500
+        example: ' '
         type: string
     type: object
   internal_api.AccentInfo:
@@ -174,6 +174,30 @@ definitions:
         example: 200
         type: integer
     type: object
+  internal_api.MarkAccentStreamChunk:
+    properties:
+      chunk:
+        example: 0
+        type: integer
+      error:
+        $ref: '#/definitions/internal_api.APIToolsError'
+      result:
+        items:
+          $ref: '#/definitions/internal_api.WordAccentResult'
+        type: array
+      status:
+        example: 200
+        type: integer
+      subchunk:
+        example: 0
+        type: integer
+    type: object
+  internal_api.ProxyErrorResponse:
+    properties:
+      error:
+        example: Failed to contact external API
+        type: string
+    type: object
   internal_api.SentenceQueryRequest:
     properties:
       id:
@@ -305,10 +329,6 @@ definitions:
       lexical_kernel_alts:
         items:
           type: integer
-        type: array
-      subword:
-        items:
-          $ref: '#/definitions/internal_api.WordAccentSubword'
         type: array
       surface:
         example: 金
@@ -553,9 +573,11 @@ paths:
     post:
       consumes:
       - application/json
-      description: Look up words in JMdict (Japanese-Multilingual Dictionary). Returns
+      description: 'Look up words in JMdict (Japanese-Multilingual Dictionary). Returns
         kanji forms, furigana readings, parts of speech, and English definitions.
-        Supports searching by kanji, kana, or romaji.
+        Supports searching by kanji, kana, or romaji. Body convention: the inner `status`
+        carries the real result code; `error` is `null` on success and populated only
+        when `status != 200`.'
       parameters:
       - description: Word to look up in the dictionary
         in: body
@@ -573,9 +595,7 @@ paths:
         "502":
           description: Bad Gateway
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/internal_api.ProxyErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Dictionary query
@@ -1258,7 +1278,9 @@ paths:
         for each word. `accent_marking_type` values: 0=low/unknown, 1=heiban (high
         plateau), 2=fall kernel. Optional flags control whether English-letter and
         katakana tokens carry furigana, and `script` rewrites every furigana field
-        to hiragana, katakana, or romaji.'
+        to hiragana, katakana, or romaji. Body convention: the inner `status` carries
+        the real result code; `error` is `null` on success and populated only when
+        `status != 200`.'
       parameters:
       - description: Japanese text to analyze for accent patterns
         in: body
@@ -1276,9 +1298,7 @@ paths:
         "502":
           description: Bad Gateway
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/internal_api.ProxyErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Mark Japanese accent
@@ -1291,7 +1311,9 @@ paths:
       description: 'Same input and per-chunk output as /v1/mark-accent, but streamed
         as NDJSON: one JSON object per line, emitted as soon as each input chunk finishes.
         Each line carries `{"chunk": <line_idx>, "subchunk": <sub_idx>, ...AccentResponse}`
-        so clients can interleave UI rendering with later chunks still in flight.'
+        so clients can interleave UI rendering with later chunks still in flight.
+        Body convention: each chunk''s inner `status` carries the real result code;
+        `error` is `null` on success and populated only when `status != 200`.'
       parameters:
       - description: Japanese text to analyze for accent patterns
         in: body
@@ -1303,15 +1325,14 @@ paths:
       - application/x-ndjson
       responses:
         "200":
-          description: NDJSON stream of per-chunk AccentResponse objects
+          description: One NDJSON line per chunk; full response is a stream of these
+            objects separated by '\\n'
           schema:
-            type: string
+            $ref: '#/definitions/internal_api.MarkAccentStreamChunk'
         "502":
           description: Bad Gateway
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/internal_api.ProxyErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Mark Japanese accent (streaming NDJSON)
@@ -1779,9 +1800,11 @@ paths:
     post:
       consumes:
       - application/json
-      description: Find example sentences containing a given word from JMdict. Requires
+      description: 'Find example sentences containing a given word from JMdict. Requires
         both the word and its JMdict entry ID (obtained from the dict-query endpoint).
-        Returns bilingual Japanese-English sentence pairs.
+        Returns bilingual Japanese-English sentence pairs. Body convention: the inner
+        `status` carries the real result code; `error` is an empty string on success
+        and populated only when `status != 200`.'
       parameters:
       - description: Word and its JMdict entry ID
         in: body
@@ -1799,9 +1822,7 @@ paths:
         "502":
           description: Bad Gateway
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/internal_api.ProxyErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Sentence query
@@ -2058,10 +2079,11 @@ paths:
     post:
       consumes:
       - application/json
-      description: Search for headwords in Japanese language corpora. Supports lookup
+      description: 'Search for headwords in Japanese language corpora. Supports lookup
         by kanji, kana, or romaji. Returns matching headword entries with readings
         and frequency data. Specify site as NLB (NINJAL LRP BCCWJ) or NLT (Tsukuba
-        Web Corpus).
+        Web Corpus). Body convention: the inner `status` carries the real result code;
+        `error` is `null` on success and populated only when `status != 200`.'
       parameters:
       - description: Word to search (kanji, kana, or romaji) and corpus site
         in: body
@@ -2079,9 +2101,7 @@ paths:
         "502":
           description: Bad Gateway
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/internal_api.ProxyErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query usage headwords
@@ -2091,10 +2111,11 @@ paths:
     post:
       consumes:
       - application/json
-      description: Retrieve detailed usage information for a specific headword by
+      description: 'Retrieve detailed usage information for a specific headword by
         its ID. Returns base form, subcorpus distribution, conjugation patterns (shojikei/katuyokei),
         and collocation data. The headword_id must be obtained from the headwords
-        endpoint first.
+        endpoint first. Body convention: the inner `status` carries the real result
+        code; `error` is `null` on success and populated only when `status != 200`.'
       parameters:
       - description: Headword ID and corpus site
         in: body
@@ -2112,9 +2133,7 @@ paths:
         "502":
           description: Bad Gateway
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/internal_api.ProxyErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query usage by ID details
@@ -2124,9 +2143,11 @@ paths:
     post:
       consumes:
       - application/json
-      description: Given a word, return URLs to the corresponding headword detail
+      description: 'Given a word, return URLs to the corresponding headword detail
         pages in the selected corpus (NLB or NLT). Uses the same request format as
-        the headwords endpoint.
+        the headwords endpoint. Body convention: the inner `status` carries the real
+        result code; `error` is `null` on success and populated only when `status
+        != 200`.'
       parameters:
       - description: Word to search and corpus site
         in: body
@@ -2144,9 +2165,7 @@ paths:
         "502":
           description: Bad Gateway
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/internal_api.ProxyErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query usage by URL

--- a/internal/api/api_tools.go
+++ b/internal/api/api_tools.go
@@ -47,13 +47,13 @@ func (a *API) proxyTo(c *gin.Context, target string, flushInterval time.Duration
 }
 
 // @Summary Mark Japanese accent
-// @Description Analyze Japanese text and return per-mora pitch (accent) patterns for each word. `accent_marking_type` values: 0=low/unknown, 1=heiban (high plateau), 2=fall kernel. Optional flags control whether English-letter and katakana tokens carry furigana, and `script` rewrites every furigana field to hiragana, katakana, or romaji.
+// @Description Analyze Japanese text and return per-mora pitch (accent) patterns for each word. `accent_marking_type` values: 0=low/unknown, 1=heiban (high plateau), 2=fall kernel. Optional flags control whether English-letter and katakana tokens carry furigana, and `script` rewrites every furigana field to hiragana, katakana, or romaji. Body convention: the inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.
 // @Tags api-tools
 // @Accept json
 // @Produce json
 // @Param body body MarkAccentRequest true "Japanese text to analyze for accent patterns"
 // @Success 200 {object} MarkAccentResponse
-// @Failure 502 {object} map[string]string
+// @Failure 502 {object} ProxyErrorResponse
 // @Security ApiKeyAuth
 // @Router /v1/mark-accent [post]
 func (a *API) MarkAccentHandler(c *gin.Context) {
@@ -61,13 +61,13 @@ func (a *API) MarkAccentHandler(c *gin.Context) {
 }
 
 // @Summary Mark Japanese accent (streaming NDJSON)
-// @Description Same input and per-chunk output as /v1/mark-accent, but streamed as NDJSON: one JSON object per line, emitted as soon as each input chunk finishes. Each line carries `{"chunk": <line_idx>, "subchunk": <sub_idx>, ...AccentResponse}` so clients can interleave UI rendering with later chunks still in flight.
+// @Description Same input and per-chunk output as /v1/mark-accent, but streamed as NDJSON: one JSON object per line, emitted as soon as each input chunk finishes. Each line carries `{"chunk": <line_idx>, "subchunk": <sub_idx>, ...AccentResponse}` so clients can interleave UI rendering with later chunks still in flight. Body convention: each chunk's inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.
 // @Tags api-tools
 // @Accept json
 // @Produce application/x-ndjson
 // @Param body body MarkAccentRequest true "Japanese text to analyze for accent patterns"
-// @Success 200 {string} string "NDJSON stream of per-chunk AccentResponse objects"
-// @Failure 502 {object} map[string]string
+// @Success 200 {object} MarkAccentStreamChunk "One NDJSON line per chunk; full response is a stream of these objects separated by '\\n'"
+// @Failure 502 {object} ProxyErrorResponse
 // @Security ApiKeyAuth
 // @Router /v1/mark-accent/stream [post]
 func (a *API) MarkAccentStreamHandler(c *gin.Context) {
@@ -75,13 +75,13 @@ func (a *API) MarkAccentStreamHandler(c *gin.Context) {
 }
 
 // @Summary Query usage headwords
-// @Description Search for headwords in Japanese language corpora. Supports lookup by kanji, kana, or romaji. Returns matching headword entries with readings and frequency data. Specify site as NLB (NINJAL LRP BCCWJ) or NLT (Tsukuba Web Corpus).
+// @Description Search for headwords in Japanese language corpora. Supports lookup by kanji, kana, or romaji. Returns matching headword entries with readings and frequency data. Specify site as NLB (NINJAL LRP BCCWJ) or NLT (Tsukuba Web Corpus). Body convention: the inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.
 // @Tags api-tools
 // @Accept json
 // @Produce json
 // @Param body body UsageQueryHeadWordsRequest true "Word to search (kanji, kana, or romaji) and corpus site"
 // @Success 200 {object} UsageQueryHeadWordsResponse
-// @Failure 502 {object} map[string]string
+// @Failure 502 {object} ProxyErrorResponse
 // @Security ApiKeyAuth
 // @Router /v1/usage-query/headwords [post]
 func (a *API) UsageQueryHeadWordsHandler(c *gin.Context) {
@@ -89,13 +89,13 @@ func (a *API) UsageQueryHeadWordsHandler(c *gin.Context) {
 }
 
 // @Summary Query usage by URL
-// @Description Given a word, return URLs to the corresponding headword detail pages in the selected corpus (NLB or NLT). Uses the same request format as the headwords endpoint.
+// @Description Given a word, return URLs to the corresponding headword detail pages in the selected corpus (NLB or NLT). Uses the same request format as the headwords endpoint. Body convention: the inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.
 // @Tags api-tools
 // @Accept json
 // @Produce json
 // @Param body body UsageQueryHeadWordsRequest true "Word to search and corpus site"
 // @Success 200 {object} UsageQueryURLResponse
-// @Failure 502 {object} map[string]string
+// @Failure 502 {object} ProxyErrorResponse
 // @Security ApiKeyAuth
 // @Router /v1/usage-query/url [post]
 func (a *API) UsageQueryURLHandler(c *gin.Context) {
@@ -103,13 +103,13 @@ func (a *API) UsageQueryURLHandler(c *gin.Context) {
 }
 
 // @Summary Query usage by ID details
-// @Description Retrieve detailed usage information for a specific headword by its ID. Returns base form, subcorpus distribution, conjugation patterns (shojikei/katuyokei), and collocation data. The headword_id must be obtained from the headwords endpoint first.
+// @Description Retrieve detailed usage information for a specific headword by its ID. Returns base form, subcorpus distribution, conjugation patterns (shojikei/katuyokei), and collocation data. The headword_id must be obtained from the headwords endpoint first. Body convention: the inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.
 // @Tags api-tools
 // @Accept json
 // @Produce json
 // @Param body body UsageQueryIDDetailsRequest true "Headword ID and corpus site"
 // @Success 200 {object} UsageQueryIDDetailsResponse
-// @Failure 502 {object} map[string]string
+// @Failure 502 {object} ProxyErrorResponse
 // @Security ApiKeyAuth
 // @Router /v1/usage-query/id-details [post]
 func (a *API) UsageQueryIDDetailsHandler(c *gin.Context) {
@@ -117,13 +117,13 @@ func (a *API) UsageQueryIDDetailsHandler(c *gin.Context) {
 }
 
 // @Summary Dictionary query
-// @Description Look up words in JMdict (Japanese-Multilingual Dictionary). Returns kanji forms, furigana readings, parts of speech, and English definitions. Supports searching by kanji, kana, or romaji.
+// @Description Look up words in JMdict (Japanese-Multilingual Dictionary). Returns kanji forms, furigana readings, parts of speech, and English definitions. Supports searching by kanji, kana, or romaji. Body convention: the inner `status` carries the real result code; `error` is `null` on success and populated only when `status != 200`.
 // @Tags api-tools
 // @Accept json
 // @Produce json
 // @Param body body DictQueryRequest true "Word to look up in the dictionary"
 // @Success 200 {object} DictQueryResponse
-// @Failure 502 {object} map[string]string
+// @Failure 502 {object} ProxyErrorResponse
 // @Security ApiKeyAuth
 // @Router /v1/dict-query [post]
 func (a *API) DictQueryHandler(c *gin.Context) {
@@ -131,13 +131,13 @@ func (a *API) DictQueryHandler(c *gin.Context) {
 }
 
 // @Summary Sentence query
-// @Description Find example sentences containing a given word from JMdict. Requires both the word and its JMdict entry ID (obtained from the dict-query endpoint). Returns bilingual Japanese-English sentence pairs.
+// @Description Find example sentences containing a given word from JMdict. Requires both the word and its JMdict entry ID (obtained from the dict-query endpoint). Returns bilingual Japanese-English sentence pairs. Body convention: the inner `status` carries the real result code; `error` is an empty string on success and populated only when `status != 200`.
 // @Tags api-tools
 // @Accept json
 // @Produce json
 // @Param body body SentenceQueryRequest true "Word and its JMdict entry ID"
 // @Success 200 {object} SentenceQueryResponse
-// @Failure 502 {object} map[string]string
+// @Failure 502 {object} ProxyErrorResponse
 // @Security ApiKeyAuth
 // @Router /v1/sentence-query [post]
 func (a *API) SentenceQueryHandler(c *gin.Context) {

--- a/internal/api/api_tools_models.go
+++ b/internal/api/api_tools_models.go
@@ -3,9 +3,22 @@ package api
 // --- Shared Models ---
 
 // APIToolsError represents an error response from the API tools service.
+// Only embedded inside per-endpoint Response structs (never returned standalone).
+// The variant nature (`null` on success, populated on failure) is documented in
+// each handler's `@Description` — swag drops sibling-of-$ref descriptions, so
+// the convention can't live on the field tag. Examples are intentionally
+// zero/empty so the composited success Example renders `{code:0, message:" "}`
+// instead of the literal `"string"` swag falls back to with no example set.
 type APIToolsError struct {
-	Code    int    `json:"code" example:"500" description:"Error code following JSON-RPC 2.0 specification"`
-	Message string `json:"message" example:"HTTP error 500" description:"Detailed error message"`
+	Code    int    `json:"code" example:"0"`
+	Message string `json:"message" example:" "`
+}
+
+// ProxyErrorResponse is what the reverse proxy writes when it cannot reach the
+// upstream api-tools service (502 Bad Gateway). Upstream-originated errors are
+// passed through unchanged and follow APIToolsError instead.
+type ProxyErrorResponse struct {
+	Error string `json:"error" example:"Failed to contact external API" description:"Human-readable reason the upstream call failed"`
 }
 
 // --- Mark Accent Models ---
@@ -27,10 +40,14 @@ type AccentInfo struct {
 }
 
 // WordAccentSubword represents sub-word decomposition within an accent result.
+// The recursive `subword` field is hidden from Swagger (`swaggerignore`) because
+// it is "reserved for compatibility; typically empty" in real responses, and
+// swag renders self-referential types as the literal `["string"]` which is
+// worse than not documenting them. The runtime JSON still carries the field.
 type WordAccentSubword struct {
 	Furigana          string              `json:"furigana" example:"かね" description:"Furigana for this sub-word"`
 	Surface           string              `json:"surface" example:"金" description:"Original text for this sub-word"`
-	Subword           []WordAccentSubword `json:"subword,omitempty" description:"Reserved for compatibility; typically empty"`
+	Subword           []WordAccentSubword `json:"subword,omitempty" swaggerignore:"true"`
 	LexicalKernel     *int                `json:"lexical_kernel,omitempty" example:"0" description:"UniDic per-morpheme kernel position (aType). 0=heiban, N>=1=kernel on mora N. null when unavailable."`
 	LexicalKernelAlts []int               `json:"lexical_kernel_alts,omitempty" description:"Alternative kernel positions for multi-reading entries"`
 }
@@ -50,7 +67,17 @@ type WordAccentResult struct {
 type MarkAccentResponse struct {
 	Status int                `json:"status" example:"200" description:"HTTP status code"`
 	Result []WordAccentResult `json:"result" description:"List of accent-marked word results"`
-	Error  *APIToolsError     `json:"error" description:"Error details, if any"`
+	Error  *APIToolsError     `json:"error"`
+}
+
+// MarkAccentStreamChunk is one NDJSON line emitted by /v1/mark-accent/stream.
+// The full response is a stream of these objects, one per line, separated by '\n'.
+type MarkAccentStreamChunk struct {
+	Chunk    int                `json:"chunk" example:"0" description:"Zero-based index of the input line this chunk belongs to"`
+	Subchunk int                `json:"subchunk" example:"0" description:"Zero-based sub-chunk index within the line"`
+	Status   int                `json:"status" example:"200" description:"HTTP status code for this chunk"`
+	Result   []WordAccentResult `json:"result" description:"List of accent-marked word results for this chunk"`
+	Error    *APIToolsError     `json:"error"`
 }
 
 // --- Usage Query: HeadWords Models ---
@@ -75,7 +102,7 @@ type HeadWord struct {
 type UsageQueryHeadWordsResponse struct {
 	Status int            `json:"status" example:"200" description:"HTTP status code"`
 	Result []HeadWord     `json:"result" description:"List of matching headwords"`
-	Error  *APIToolsError `json:"error" description:"Error details, if any"`
+	Error  *APIToolsError `json:"error"`
 }
 
 // --- Usage Query: URL Models ---
@@ -90,7 +117,7 @@ type UsageQueryWordURL struct {
 type UsageQueryURLResponse struct {
 	Status int                 `json:"status" example:"200" description:"HTTP status code"`
 	Result []UsageQueryWordURL `json:"result" description:"List of headword URLs"`
-	Error  *APIToolsError      `json:"error" description:"Error details, if any"`
+	Error  *APIToolsError      `json:"error"`
 }
 
 // --- Usage Query: IdDetails Models ---
@@ -116,7 +143,7 @@ type IdDetails struct {
 type UsageQueryIDDetailsResponse struct {
 	Status int            `json:"status" example:"200" description:"HTTP status code"`
 	Result *IdDetails     `json:"result" description:"Detailed word usage data"`
-	Error  *APIToolsError `json:"error" description:"Error details, if any"`
+	Error  *APIToolsError `json:"error"`
 }
 
 // --- Dictionary Query Models ---
@@ -144,7 +171,7 @@ type DictQueryWordResult struct {
 type DictQueryResponse struct {
 	Status int                   `json:"status" example:"200" description:"HTTP status code"`
 	Result []DictQueryWordResult `json:"result" description:"List of dictionary word results"`
-	Error  *APIToolsError        `json:"error" description:"Error details, if any"`
+	Error  *APIToolsError        `json:"error"`
 }
 
 // --- Sentence Query Models ---
@@ -172,5 +199,5 @@ type SentenceQueryWordResult struct {
 type SentenceQueryResponse struct {
 	Status int                      `json:"status" example:"200" description:"HTTP status code"`
 	Result *SentenceQueryWordResult `json:"result" description:"Sentence query results for the word"`
-	Error  string                   `json:"error" description:"Error message, if any"`
+	Error  string                   `json:"error"`
 }

--- a/internal/api/api_tools_models.go
+++ b/internal/api/api_tools_models.go
@@ -66,7 +66,7 @@ type WordAccentResult struct {
 // MarkAccentResponse is the response from the mark-accent endpoint.
 type MarkAccentResponse struct {
 	Status int                `json:"status" example:"200" description:"HTTP status code"`
-	Result []WordAccentResult `json:"result" description:"List of accent-marked word results"`
+	Result []WordAccentResult `json:"result" extensions:"x-nullable=true" description:"List of accent-marked word results; null when status != 200"`
 	Error  *APIToolsError     `json:"error"`
 }
 
@@ -76,7 +76,7 @@ type MarkAccentStreamChunk struct {
 	Chunk    int                `json:"chunk" example:"0" description:"Zero-based index of the input line this chunk belongs to"`
 	Subchunk int                `json:"subchunk" example:"0" description:"Zero-based sub-chunk index within the line"`
 	Status   int                `json:"status" example:"200" description:"HTTP status code for this chunk"`
-	Result   []WordAccentResult `json:"result" description:"List of accent-marked word results for this chunk"`
+	Result   []WordAccentResult `json:"result" extensions:"x-nullable=true" description:"List of accent-marked word results for this chunk; null when this chunk's status != 200"`
 	Error    *APIToolsError     `json:"error"`
 }
 
@@ -101,7 +101,7 @@ type HeadWord struct {
 // UsageQueryHeadWordsResponse is the response from the usage-query/headwords endpoint.
 type UsageQueryHeadWordsResponse struct {
 	Status int            `json:"status" example:"200" description:"HTTP status code"`
-	Result []HeadWord     `json:"result" description:"List of matching headwords"`
+	Result []HeadWord     `json:"result" extensions:"x-nullable=true" description:"List of matching headwords; null when status != 200"`
 	Error  *APIToolsError `json:"error"`
 }
 
@@ -116,7 +116,7 @@ type UsageQueryWordURL struct {
 // UsageQueryURLResponse is the response from the usage-query/url endpoint.
 type UsageQueryURLResponse struct {
 	Status int                 `json:"status" example:"200" description:"HTTP status code"`
-	Result []UsageQueryWordURL `json:"result" description:"List of headword URLs"`
+	Result []UsageQueryWordURL `json:"result" extensions:"x-nullable=true" description:"List of headword URLs; null when status != 200"`
 	Error  *APIToolsError      `json:"error"`
 }
 
@@ -142,7 +142,7 @@ type IdDetails struct {
 // UsageQueryIDDetailsResponse is the response from the usage-query/id-details endpoint.
 type UsageQueryIDDetailsResponse struct {
 	Status int            `json:"status" example:"200" description:"HTTP status code"`
-	Result *IdDetails     `json:"result" description:"Detailed word usage data"`
+	Result *IdDetails     `json:"result" extensions:"x-nullable=true" description:"Detailed word usage data; null when status != 200"`
 	Error  *APIToolsError `json:"error"`
 }
 
@@ -170,7 +170,7 @@ type DictQueryWordResult struct {
 // DictQueryResponse is the response from the dict-query endpoint.
 type DictQueryResponse struct {
 	Status int                   `json:"status" example:"200" description:"HTTP status code"`
-	Result []DictQueryWordResult `json:"result" description:"List of dictionary word results"`
+	Result []DictQueryWordResult `json:"result" extensions:"x-nullable=true" description:"List of dictionary word results; null when status != 200"`
 	Error  *APIToolsError        `json:"error"`
 }
 
@@ -198,6 +198,6 @@ type SentenceQueryWordResult struct {
 // SentenceQueryResponse is the response from the sentence-query endpoint.
 type SentenceQueryResponse struct {
 	Status int                      `json:"status" example:"200" description:"HTTP status code"`
-	Result *SentenceQueryWordResult `json:"result" description:"Sentence query results for the word"`
+	Result *SentenceQueryWordResult `json:"result" extensions:"x-nullable=true" description:"Sentence query results for the word; null when status != 200"`
 	Error  string                   `json:"error"`
 }


### PR DESCRIPTION
<!-- Stacked on top of #38 (feat/api-tools). Once #38 merges to main, GitHub will auto-rebase this PR's base onto main. -->

### 目的
Swagger UI 上 `/v1/mark-accent/stream` 的 Example Value 只顯示一個字面 `"string"`，跟實際 NDJSON 完全對不起來（#50）。順手把其他 api-tools proxy 路由幾個會誤導使用者的 schema 雷一起修掉。

### 方法／實作說明

- 主要修改：
  - `internal/api/api_tools.go`：handler annotations（`@Success` / `@Failure` / `@Description`）
  - `internal/api/api_tools_models.go`：新增 `MarkAccentStreamChunk` / `ProxyErrorResponse`，調整 `APIToolsError` 與 `WordAccentSubword`，清理 dead description tags
  - `docs/swagger/{docs.go,swagger.json,swagger.yaml}`：`make swag` 重新產生

- 關鍵實作：
  - **Stream chunk 真實 shape**：`@Success 200 {string} string` → `{object} MarkAccentStreamChunk`，包含 `{chunk, subchunk, status, result, error}` 五個 top-level 欄位（對照實際 payload 確認）。
  - **502 不再是泛型 map**：新增 `ProxyErrorResponse { error string }`，與 `proxyTo` 的 `ErrorHandler` 實際輸出 `{"error": "Failed to contact external API"}` 對齊；7 個 handler 的 `@Failure 502` 全部換掉。
  - **APIToolsError 嵌入時的 example**：原本是 `code:500 / message:"HTTP error 500"`，在 200 success response 的合成 example 裡造成 `status:200` 卻 `error.code:500` 的矛盾畫面。改成 `code:0 / message:" "`（swag 不接受空字串，會 fallback 成字面 `"string"`，所以用單空白）。
  - **遞迴 subword**：`WordAccentSubword.Subword`（自我引用 `[]WordAccentSubword`）標 `swaggerignore:"true"`，因為 swag 把 self-referential type 渲染成 `["string"]`；該欄位 description 本就是「reserved for compatibility; typically empty」，runtime JSON 仍然輸出。
  - **`error` 欄位的 variant 註記**：每個 handler 的 `@Description` 末尾追加 `Body convention: the inner status carries the real result code; error is null on success and populated only when status != 200.`（swag 在 OpenAPI 2.0 模式下會丟棄 `\$ref` 欄位上的 sibling `description`，所以欄位標籤上寫不下，搬到 endpoint description 才看得到）。

### 關聯 Issue

Closes #50

### 附註

- Stacked on #38（`feat/api-tools`）——`api_tools_models.go` 與 stream endpoint 都來自 7db676f，main 還沒有。一旦 #38 合進 main，這個 PR 的 base 會自動跟著移過去。
- 純文件 / annotation 改動，runtime 行為（reverse-proxy 的 bytes 直接 pass-through）零變化。
- TODO：
  - [ ] reviewer 在 Swagger UI 確認 `/v1/mark-accent/stream` 的 Example Value 已是 chunk shape，502 example 顯示 `{"error": "..."}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)