### PR TITLE
feat: implement guild management 3.4 to 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ certs/
 .opencode/
 .claude/
 .gemini/
+.omo/
 
 # Temporary files
 tmp/

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -891,80 +891,6 @@ const docTemplate = `{
                     }
                 }
             },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "guilds"
-                ],
-                "summary": "Update a guild",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Guild ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Guild data",
-                        "name": "guild",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jpcorrect-backend_internal_domain.Guild"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jpcorrect-backend_internal_domain.Guild"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
             "delete": {
                 "consumes": [
                     "application/json"
@@ -1009,6 +935,114 @@ const docTemplate = `{
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/guilds/{id}/invite-link": {
+            "get": {
+                "description": "Get the currently active invite link for a guild. Returns 200 with null if expired or not found.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "guilds"
+                ],
+                "summary": "Get active guild invite link",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Guild ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns the active invite link, or null if expired or not found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.GuildInviteResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid Guild ID format",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new active invite link for a guild and expires any existing active links within a single transaction.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "guilds"
+                ],
+                "summary": "Create a new guild invite link",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Guild ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Invite Link Options (e.g. {",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/jpcorrect-backend_internal_domain.GuildInvite"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jpcorrect-backend_internal_domain.GuildInvite"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid Guild ID or Request Body",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2668,6 +2702,20 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_api.GuildInviteResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                }
+            }
+        },
         "jpcorrect-backend_internal_domain.Event": {
             "type": "object",
             "properties": {
@@ -2820,6 +2868,29 @@ const docTemplate = `{
                 "GuildAttendeeRoleMember",
                 "GuildAttendeeRoleMaster"
             ]
+        },
+        "jpcorrect-backend_internal_domain.GuildInvite": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "ttl_seconds": {
+                    "type": "integer"
+                }
+            }
         },
         "jpcorrect-backend_internal_domain.Mistake": {
             "type": "object",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -885,80 +885,6 @@
                     }
                 }
             },
-            "put": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "guilds"
-                ],
-                "summary": "Update a guild",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Guild ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Guild data",
-                        "name": "guild",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jpcorrect-backend_internal_domain.Guild"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jpcorrect-backend_internal_domain.Guild"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
             "delete": {
                 "consumes": [
                     "application/json"
@@ -1003,6 +929,114 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/guilds/{id}/invite-link": {
+            "get": {
+                "description": "Get the currently active invite link for a guild. Returns 200 with null if expired or not found.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "guilds"
+                ],
+                "summary": "Get active guild invite link",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Guild ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns the active invite link, or null if expired or not found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.GuildInviteResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid Guild ID format",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new active invite link for a guild and expires any existing active links within a single transaction.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "guilds"
+                ],
+                "summary": "Create a new guild invite link",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Guild ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Invite Link Options (e.g. {",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/jpcorrect-backend_internal_domain.GuildInvite"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jpcorrect-backend_internal_domain.GuildInvite"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid Guild ID or Request Body",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2662,6 +2696,20 @@
                 }
             }
         },
+        "internal_api.GuildInviteResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                }
+            }
+        },
         "jpcorrect-backend_internal_domain.Event": {
             "type": "object",
             "properties": {
@@ -2814,6 +2862,29 @@
                 "GuildAttendeeRoleMember",
                 "GuildAttendeeRoleMaster"
             ]
+        },
+        "jpcorrect-backend_internal_domain.GuildInvite": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "guild_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "ttl_seconds": {
+                    "type": "integer"
+                }
+            }
         },
         "jpcorrect-backend_internal_domain.Mistake": {
             "type": "object",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -8,6 +8,15 @@ definitions:
         description: Valid is true if Time is not NULL
         type: boolean
     type: object
+  internal_api.GuildInviteResponse:
+    properties:
+      code:
+        type: string
+      created_at:
+        type: string
+      expires_at:
+        type: string
+    type: object
   jpcorrect-backend_internal_domain.Event:
     properties:
       actual_duration:
@@ -112,6 +121,21 @@ definitions:
     x-enum-varnames:
     - GuildAttendeeRoleMember
     - GuildAttendeeRoleMaster
+  jpcorrect-backend_internal_domain.GuildInvite:
+    properties:
+      code:
+        type: string
+      created_at:
+        type: string
+      expires_at:
+        type: string
+      guild_id:
+        type: string
+      id:
+        type: string
+      ttl_seconds:
+        type: integer
+    type: object
   jpcorrect-backend_internal_domain.Mistake:
     properties:
       comment:
@@ -850,42 +874,67 @@ paths:
       summary: Get a guild by ID
       tags:
       - guilds
-    put:
+  /v1/guilds/{id}/invite-link:
+    get:
       consumes:
       - application/json
+      description: Get the currently active invite link for a guild. Returns 200 with
+        null if expired or not found.
       parameters:
       - description: Guild ID
+        format: uuid
         in: path
         name: id
         required: true
         type: string
-      - description: Guild data
-        in: body
-        name: guild
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Returns the active invite link, or null if expired or not found
+          schema:
+            $ref: '#/definitions/internal_api.GuildInviteResponse'
+        "400":
+          description: Invalid Guild ID format
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal server error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get active guild invite link
+      tags:
+      - guilds
+    post:
+      consumes:
+      - application/json
+      description: Creates a new active invite link for a guild and expires any existing
+        active links within a single transaction.
+      parameters:
+      - description: Guild ID
+        format: uuid
+        in: path
+        name: id
         required: true
+        type: string
+      - description: Invite Link Options (e.g. {
+        in: body
+        name: request
         schema:
-          $ref: '#/definitions/jpcorrect-backend_internal_domain.Guild'
+          $ref: '#/definitions/jpcorrect-backend_internal_domain.GuildInvite'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/jpcorrect-backend_internal_domain.Guild'
+            $ref: '#/definitions/jpcorrect-backend_internal_domain.GuildInvite'
         "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "404":
-          description: Not Found
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "409":
-          description: Conflict
+          description: Invalid Guild ID or Request Body
           schema:
             additionalProperties:
               type: string
@@ -896,7 +945,7 @@ paths:
             additionalProperties:
               type: string
             type: object
-      summary: Update a guild
+      summary: Create a new guild invite link
       tags:
       - guilds
   /v1/mark-accent:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -158,6 +158,8 @@ func Register(r *gin.Engine, api *API) {
 			guilds.POST("/:id/invite-link", api.GuildInviteLinkCreateHandler)
 			guilds.POST("/:id/applications", api.GuildApplicationCreateHandler)
 			guilds.GET("/:id/applications", api.GuildApplicationsHandler)
+			guilds.POST("/:id/applications/:app_id/approve", api.GuildApplicationApproveHandler)
+			guilds.POST("/:id/applications/:app_id/reject", api.GuildApplicationRejectHandler)
 		}
 
 		// Guild Attendees

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -150,6 +150,8 @@ func Register(r *gin.Engine, api *API) {
 			guilds.GET("/:id", api.GuildGetHandler)
 			guilds.PUT("/:id", api.GuildUpdateHandler)
 			guilds.DELETE("/:id", api.GuildDeleteHandler)
+			guilds.POST("/:id/transfer-leader", api.GuildTransferLeaderHandler)
+			guilds.GET("/:id/invite-link", api.GuildInviteLinkGetHandler)
 		}
 
 		// Guild Attendees

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -144,7 +144,7 @@ func Register(r *gin.Engine, api *API) {
 		}
 
 		// Guilds
-		guilds := v1.Group("/guilds", api.AuthMiddleware())
+		guilds := v1.Group("/guilds")
 		{
 			guilds.POST("", api.GuildCreateHandler)
 			guilds.GET("/:id", api.GuildGetHandler)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -166,6 +166,7 @@ func Register(r *gin.Engine, api *API) {
 			guilds.GET("/:id/default-slot", api.GuildDefaultSlotGetHandler)
 			guilds.PUT("/:id/default-slot", api.GuildDefaultSlotUpsertHandler)
 			guilds.DELETE("/:id/default-slot", api.GuildDefaultSlotDeleteHandler)
+			guilds.GET("/discover", api.GuildDiscoverHandler)
 		}
 
 		// Guild Attendees

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -152,6 +152,7 @@ func Register(r *gin.Engine, api *API) {
 			guilds.DELETE("/:id", api.GuildDeleteHandler)
 			guilds.POST("/:id/transfer-leader", api.GuildTransferLeaderHandler)
 			guilds.GET("/:id/invite-link", api.GuildInviteLinkGetHandler)
+			guilds.POST("/:id/invite-link", api.GuildInviteLinkCreateHandler)
 		}
 
 		// Guild Attendees

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -144,7 +144,7 @@ func Register(r *gin.Engine, api *API) {
 		}
 
 		// Guilds
-		guilds := v1.Group("/guilds")
+		guilds := v1.Group("/guilds", api.AuthMiddleware())
 		{
 			guilds.POST("", api.GuildCreateHandler)
 			guilds.GET("/:id", api.GuildGetHandler)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -164,6 +164,8 @@ func Register(r *gin.Engine, api *API) {
 			guilds.POST("/:id/applications/:app_id/approve", api.GuildApplicationApproveHandler)
 			guilds.POST("/:id/applications/:app_id/reject", api.GuildApplicationRejectHandler)
 			guilds.GET("/:id/default-slot", api.GuildDefaultSlotGetHandler)
+			guilds.PUT("/:id/default-slot", api.GuildDefaultSlotUpsertHandler)
+			guilds.DELETE("/:id/default-slot", api.GuildDefaultSlotDeleteHandler)
 		}
 
 		// Guild Attendees

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -34,6 +34,7 @@ type API struct {
 	guildRepo         domain.GuildRepository
 	guildAttendeeRepo domain.GuildAttendeeRepository
 	applicationRepo   domain.GuildApplicationRepository
+	defaultSlotRepo   domain.GuildDefaultSlotRepository
 	eventRepo         domain.EventRepository
 	eventAttendeeRepo domain.EventAttendeeRepository
 	transcriptRepo    domain.TranscriptRepository
@@ -48,6 +49,7 @@ func NewAPI(url string, transport *http.Transport, db *gorm.DB, jwksURL string, 
 	guildRepo := repository.NewGormGuildRepository(db)
 	guildAttendeeRepo := repository.NewGormGuildAttendeeRepository(db)
 	applicationRepo := repository.NewGuildApplicationRepository(db)
+	defaultSlotRepo := repository.NewGuildDefaultSlotRepository(db)
 	eventRepo := repository.NewGormEventRepository(db)
 	eventAttendeeRepo := repository.NewGormEventAttendeeRepository(db)
 	transcriptRepo := repository.NewGormTranscriptRepository(db)
@@ -85,6 +87,7 @@ func NewAPI(url string, transport *http.Transport, db *gorm.DB, jwksURL string, 
 		guildRepo:         guildRepo,
 		guildAttendeeRepo: guildAttendeeRepo,
 		applicationRepo:   applicationRepo,
+		defaultSlotRepo:   defaultSlotRepo,
 		eventRepo:         eventRepo,
 		eventAttendeeRepo: eventAttendeeRepo,
 		transcriptRepo:    transcriptRepo,
@@ -160,6 +163,7 @@ func Register(r *gin.Engine, api *API) {
 			guilds.GET("/:id/applications", api.GuildApplicationsHandler)
 			guilds.POST("/:id/applications/:app_id/approve", api.GuildApplicationApproveHandler)
 			guilds.POST("/:id/applications/:app_id/reject", api.GuildApplicationRejectHandler)
+			guilds.GET("/:id/default-slot", api.GuildDefaultSlotGetHandler)
 		}
 
 		// Guild Attendees

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -33,6 +33,7 @@ type API struct {
 	userRepo          domain.UserRepository
 	guildRepo         domain.GuildRepository
 	guildAttendeeRepo domain.GuildAttendeeRepository
+	applicationRepo   domain.GuildApplicationRepository
 	eventRepo         domain.EventRepository
 	eventAttendeeRepo domain.EventAttendeeRepository
 	transcriptRepo    domain.TranscriptRepository
@@ -46,6 +47,7 @@ func NewAPI(url string, transport *http.Transport, db *gorm.DB, jwksURL string, 
 	userRepo := repository.NewGormUserRepository(db)
 	guildRepo := repository.NewGormGuildRepository(db)
 	guildAttendeeRepo := repository.NewGormGuildAttendeeRepository(db)
+	applicationRepo := repository.NewGuildApplicationRepository(db)
 	eventRepo := repository.NewGormEventRepository(db)
 	eventAttendeeRepo := repository.NewGormEventAttendeeRepository(db)
 	transcriptRepo := repository.NewGormTranscriptRepository(db)
@@ -82,6 +84,7 @@ func NewAPI(url string, transport *http.Transport, db *gorm.DB, jwksURL string, 
 		userRepo:          userRepo,
 		guildRepo:         guildRepo,
 		guildAttendeeRepo: guildAttendeeRepo,
+		applicationRepo:   applicationRepo,
 		eventRepo:         eventRepo,
 		eventAttendeeRepo: eventAttendeeRepo,
 		transcriptRepo:    transcriptRepo,
@@ -153,6 +156,8 @@ func Register(r *gin.Engine, api *API) {
 			guilds.POST("/:id/transfer-leader", api.GuildTransferLeaderHandler)
 			guilds.GET("/:id/invite-link", api.GuildInviteLinkGetHandler)
 			guilds.POST("/:id/invite-link", api.GuildInviteLinkCreateHandler)
+			guilds.POST("/:id/applications", api.GuildApplicationCreateHandler)
+			guilds.GET("/:id/applications", api.GuildApplicationsHandler)
 		}
 
 		// Guild Attendees

--- a/internal/api/guild.go
+++ b/internal/api/guild.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"jpcorrect-backend/internal/domain"
 
@@ -69,7 +70,7 @@ func (a *API) GuildCreateHandler(c *gin.Context) {
 		return
 	}
 
-	// 檢查 Caller 已建立公會數
+	// Check the number of guilds established by the caller.
 	count, err := a.guildRepo.CountMasterGuildsByUserID(ctx, userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -86,12 +87,12 @@ func (a *API) GuildCreateHandler(c *gin.Context) {
 		return
 	}
 
-	// 建立 Attendee 實體
 	attendee := domain.GuildAttendee{
 		UserID: userID,
 		Role:   domain.GuildAttendeeRoleMaster,
 	}
 
+	// Write Guild and GuildAttendee within the same transaction.
 	if err := a.guildRepo.CreateWithMaster(c.Request.Context(), &guild, &attendee); err != nil {
 		if errors.Is(err, domain.ErrDuplicateEntry) {
 			c.JSON(http.StatusConflict, gin.H{"error": "Guild already exists"})
@@ -116,7 +117,6 @@ func (a *API) GuildCreateHandler(c *gin.Context) {
 // @Failure 409 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /v1/guilds/{id} [put]
-
 type UpdateGuildRequest struct {
 	Name        *string `json:"name" binding:"omitempty,max=100"`
 	Description *string `json:"description" binding:"omitempty,max=500"`
@@ -212,6 +212,54 @@ func (a *API) GuildDeleteHandler(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
+// @Summary Transfer guild leadership
+// @Description Transfer the master/leader role of a guild to another member
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param id path string true "Guild ID"
+// @Param request body TransferLeaderRequest true "New leader user ID"
+// @Success 200 {object} map[string]string "leader transferred successfully"
+// @Failure 400 {object} map[string]string "Invalid UUID format or user is not a member"
+// @Failure 404 {object} map[string]string "Guild not found"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/guilds/{id}/transfer-leader [post]
+type TransferLeaderRequest struct {
+	NewLeaderUserID uuid.UUID `json:"new_leader_user_id" binding:"required"`
+}
+
+func (a *API) GuildTransferLeaderHandler(c *gin.Context) {
+	idStr := c.Param("id")
+	guildID, err := uuid.Parse(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid UUID format"})
+		return
+	}
+
+	var req TransferLeaderRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// 呼叫 Repo 執行 Transaction 更新
+	err = a.guildRepo.TransferLeader(c.Request.Context(), guildID, req.NewLeaderUserID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Guild not found"})
+			return
+		}
+		if errors.Is(err, domain.ErrNotGuildMember) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "New leader must be a member of the guild"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "leader transferred successfully"})
+}
+
 // @Summary Get a guild attendee by ID
 // @Tags guild-attendees
 // @Accept json
@@ -241,6 +289,42 @@ func (a *API) GuildAttendeeGetHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, attendee)
+}
+
+type GuildInviteResponse struct {
+	Code      string     `json:"code"`
+	ExpiresAt *time.Time `json:"expires_at"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+func (a *API) GuildInviteLinkGetHandler(c *gin.Context) {
+	guildIDParam := c.Param("id")
+	guildID, err := uuid.Parse(guildIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
+		return
+	}
+
+	invite, err := a.guildRepo.GetActiveInviteByGuildID(c.Request.Context(), guildID, time.Now())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch invite link"})
+		return
+	}
+
+	// 若已過期或無 row，invite 為 nil，Go 的 JSON 序列化會自動輸出 200 + null
+	if invite == nil {
+		c.JSON(http.StatusOK, nil)
+		return
+	}
+
+	// 轉成 Response 格式或直接回傳 invite
+	resp := GuildInviteResponse{
+		Code:      invite.Code,
+		ExpiresAt: invite.ExpiresAt,
+		CreatedAt: invite.CreatedAt,
+	}
+
+	c.JSON(http.StatusOK, resp)
 }
 
 // @Summary Create a guild attendee

--- a/internal/api/guild.go
+++ b/internal/api/guild.go
@@ -808,6 +808,53 @@ func (a *API) GuildApplicationRejectHandler(c *gin.Context) {
 	})
 }
 
+// GuildDefaultSlotGetHandler retrieves the default time slot (may be null)
+// @Summary Get guild default slot
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param id path string true "Guild ID (UUID)" format(uuid)
+// @Success 200 {object} map[string]interface{} "Success (data field contains GuildDefaultSlot or null)"
+// @Failure 400 {object} map[string]string "Invalid guild_id format"
+// @Failure 404 {object} map[string]string "Guild not found"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/guilds/{id}/default-slot [get]
+func (a *API) GuildDefaultSlotGetHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	guildID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
+		return
+	}
+
+	_, err = a.guildRepo.GetByID(ctx, guildID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "guild not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query guild"})
+		return
+	}
+
+	// Query the Guild's preset time slots.
+	slot, err := a.defaultSlotRepo.GetByGuildID(ctx, guildID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusOK, gin.H{
+				"data": nil,
+			})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query default slot"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data": slot,
+	})
+}
+
 // @Summary Get a guild attendee by ID
 // @Tags guild-attendees
 // @Accept json

--- a/internal/api/guild.go
+++ b/internal/api/guild.go
@@ -286,12 +286,6 @@ func (a *API) GuildTransferLeaderHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "leader transferred successfully"})
 }
 
-type GuildInviteResponse struct {
-	Code      string     `json:"code"`
-	ExpiresAt *time.Time `json:"expires_at"`
-	CreatedAt time.Time  `json:"created_at"`
-}
-
 // @Summary Get active guild invite link
 // @Description Get the currently active invite link for a guild. Returns 200 with null if expired or not found.
 // @Tags guilds
@@ -302,6 +296,12 @@ type GuildInviteResponse struct {
 // @Failure 400 {object} map[string]string "Invalid Guild ID format"
 // @Failure 500 {object} map[string]string "Internal server error"
 // @Router /v1/guilds/{id}/invite-link [get]
+type GuildInviteResponse struct {
+	Code      string     `json:"code"`
+	ExpiresAt *time.Time `json:"expires_at"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
 func (a *API) GuildInviteLinkGetHandler(c *gin.Context) {
 	guildIDParam := c.Param("id")
 	guildID, err := uuid.Parse(guildIDParam)
@@ -445,6 +445,190 @@ func (a *API) GuildInviteLinkCreateHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, newInvite)
+}
+
+type GuildApplicationResponse struct {
+	ID        uuid.UUID                     `json:"id"`
+	GuildID   uuid.UUID                     `json:"guild_id"`
+	UserID    uuid.UUID                     `json:"user_id"`
+	Status    domain.GuildApplicationStatus `json:"status"`
+	CreatedAt time.Time                     `json:"created_at"`
+	UpdatedAt time.Time                     `json:"updated_at"`
+}
+
+// @Summary Submit guild application
+// @Description Submit an application to join a guild. Fails if caller is already a member or has a pending application.
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param id path string true "Guild ID" format(uuid)
+// @Success 201 {object} GuildApplicationResponse "Application created successfully"
+// @Failure 400 {object} map[string]string "Invalid Guild ID, already a member, or pending application exists"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Failure 404 {object} map[string]string "Guild not found"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/guilds/{id}/applications [post]
+func (a *API) GuildApplicationCreateHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	guildIDParam := c.Param("id")
+	guildID, err := uuid.Parse(guildIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
+		return
+	}
+
+	callerIDVal, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	callerID, ok := callerIDVal.(uuid.UUID)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user ID type in context"})
+		return
+	}
+
+	// Check if the guild exists
+	_, err = a.guildRepo.GetByID(ctx, guildID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "guild not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query guild"})
+		return
+	}
+
+	// Check if the caller already belongs to the guild.
+	attendee, err := a.guildAttendeeRepo.GetByGuildAndUser(ctx, guildID, callerID)
+	if err != nil && !errors.Is(err, domain.ErrNotFound) {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check attendee status"})
+		return
+	}
+	if attendee != nil && attendee.LeftAt == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "you are already a member of this guild"})
+		return
+	}
+
+	// Check if already application with a "Pending" status exists.
+	pendingApp, err := a.applicationRepo.GetPendingByGuildAndUser(ctx, guildID, callerID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check existing applications"})
+		return
+	}
+	if pendingApp != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "you already have a pending application for this guild"})
+		return
+	}
+
+	now := time.Now()
+	newApp := &domain.GuildApplication{
+		ID:        uuid.New(),
+		GuildID:   guildID,
+		UserID:    callerID,
+		Status:    domain.GuildApplicationStatusPending,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := a.applicationRepo.Create(ctx, newApp); err != nil {
+		if errors.Is(err, domain.ErrDuplicateEntry) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "you already have a pending application for this guild"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create application"})
+		return
+	}
+
+	resp := GuildApplicationResponse{
+		ID:        newApp.ID,
+		GuildID:   newApp.GuildID,
+		UserID:    newApp.UserID,
+		Status:    newApp.Status,
+		CreatedAt: newApp.CreatedAt,
+		UpdatedAt: newApp.UpdatedAt,
+	}
+
+	c.JSON(http.StatusCreated, resp)
+}
+
+// @Summary List pending guild applications
+// @Description Get all pending join applications for a specific guild. Caller must be the guild master or a member.
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param id path string true "Guild ID" format(uuid)
+// @Success 200 {object} ListGuildApplicationsResponse "List of pending applications"
+// @Failure 400 {object} map[string]string "Invalid Guild ID format"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Failure 403 {object} map[string]string "Forbidden - Caller is not a member or master of the guild"
+// @Failure 404 {object} map[string]string "Guild not found"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/guilds/{id}/applications [get]
+type ListGuildApplicationsResponse struct {
+	Applications []*domain.GuildApplication `json:"applications"`
+}
+
+func (a *API) GuildApplicationsHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	guildIDParam := c.Param("id")
+	guildID, err := uuid.Parse(guildIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
+		return
+	}
+
+	callerIDVal, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	callerID, ok := callerIDVal.(uuid.UUID)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user ID type in context"})
+		return
+	}
+
+	// Check if the guild exists
+	_, err = a.guildRepo.GetByID(ctx, guildID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "guild not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query guild"})
+		return
+	}
+
+	// Check if the caller is a member of the guild
+	attendee, err := a.guildAttendeeRepo.GetByGuildAndUser(ctx, guildID, callerID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: you are not a member of this guild"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check member permission"})
+		return
+	}
+	if attendee.LeftAt != nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: you have left this guild"})
+		return
+	}
+
+	// Query all pending applications.
+	apps, err := a.applicationRepo.ListPendingByGuildID(ctx, guildID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch applications"})
+		return
+	}
+	if apps == nil {
+		apps = []*domain.GuildApplication{}
+	}
+
+	c.JSON(http.StatusOK, ListGuildApplicationsResponse{
+		Applications: apps,
+	})
 }
 
 // @Summary Get a guild attendee by ID

--- a/internal/api/guild.go
+++ b/internal/api/guild.go
@@ -631,6 +631,183 @@ func (a *API) GuildApplicationsHandler(c *gin.Context) {
 	})
 }
 
+// @Summary Approve guild application
+// @Description Approve a pending application to join the guild. Adds the user as a member and cancels their pending applications for other guilds in a single transaction. Only guild master can perform this.
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param id path string true "Guild ID" format(uuid)
+// @Param app_id path string true "Application ID" format(uuid)
+// @Success 200 {object} map[string]string "Application approved successfully"
+// @Failure 400 {object} map[string]string "Invalid ID format or application not in pending status"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Failure 403 {object} map[string]string "Forbidden - Only guild master can approve"
+// @Failure 404 {object} map[string]string "Guild or Application not found"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/guilds/{id}/applications/{app_id}/approve [post]
+func (a *API) GuildApplicationApproveHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	guildID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
+		return
+	}
+
+	appID, err := uuid.Parse(c.Param("app_id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid application_id"})
+		return
+	}
+
+	callerIDVal, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	callerID, ok := callerIDVal.(uuid.UUID)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user ID type in context"})
+		return
+	}
+
+	// Check if the caller is the master of the guild
+	callerAttendee, err := a.guildAttendeeRepo.GetByGuildAndUser(ctx, guildID, callerID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: you are not a member of this guild"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify caller permission"})
+		return
+	}
+
+	if callerAttendee.LeftAt != nil || callerAttendee.Role != domain.GuildAttendeeRoleMaster {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: only guild master can approve applications"})
+		return
+	}
+
+	// Query the application and verify its status
+	app, err := a.applicationRepo.GetByID(ctx, appID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "application not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query application"})
+		return
+	}
+
+	if app.GuildID != guildID {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "application does not belong to this guild"})
+		return
+	}
+	if app.Status != domain.GuildApplicationStatusPending {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "application is not in pending status"})
+		return
+	}
+
+	newAttendee := &domain.GuildAttendee{
+		GuildID: guildID,
+		UserID:  app.UserID,
+		Role:    domain.GuildAttendeeRoleMember,
+	}
+
+	if err := a.applicationRepo.ApproveWithTx(ctx, app, newAttendee); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to approve application"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "application approved successfully",
+	})
+}
+
+// @Summary Reject guild application
+// @Description Reject a pending application to join the guild. Only guild master can perform this.
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param id path string true "Guild ID" format(uuid)
+// @Param app_id path string true "Application ID" format(uuid)
+// @Success 200 {object} map[string]string "Application rejected successfully"
+// @Failure 400 {object} map[string]string "Invalid ID format or application not in pending status"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Failure 403 {object} map[string]string "Forbidden - Only guild master can reject"
+// @Failure 404 {object} map[string]string "Guild or Application not found"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/guilds/{id}/applications/{app_id}/reject [post]
+func (a *API) GuildApplicationRejectHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	guildID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
+		return
+	}
+	appID, err := uuid.Parse(c.Param("app_id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid application_id"})
+		return
+	}
+
+	callerIDVal, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	callerID, ok := callerIDVal.(uuid.UUID)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user ID type in context"})
+		return
+	}
+
+	// Check if the caller is the master of the guild
+	callerAttendee, err := a.guildAttendeeRepo.GetByGuildAndUser(ctx, guildID, callerID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: you are not a member of this guild"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify caller permission"})
+		return
+	}
+
+	if callerAttendee.LeftAt != nil || callerAttendee.Role != domain.GuildAttendeeRoleMaster {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: only guild master can reject applications"})
+		return
+	}
+
+	// Query the application and verify its status
+	app, err := a.applicationRepo.GetByID(ctx, appID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "application not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query application"})
+		return
+	}
+
+	if app.GuildID != guildID {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "application does not belong to this guild"})
+		return
+	}
+	if app.Status != domain.GuildApplicationStatusPending {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "application is not in pending status"})
+		return
+	}
+
+	// Update status to "rejected"
+	app.Status = domain.GuildApplicationStatusRejected
+	if err := a.applicationRepo.Update(ctx, app); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to reject application"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "application rejected successfully",
+	})
+}
+
 // @Summary Get a guild attendee by ID
 // @Tags guild-attendees
 // @Accept json

--- a/internal/api/guild.go
+++ b/internal/api/guild.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"jpcorrect-backend/internal/domain"
@@ -77,7 +79,7 @@ func (a *API) GuildCreateHandler(c *gin.Context) {
 		return
 	}
 	if count >= 1 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "user has already created a guild"})
+		c.JSON(http.StatusConflict, gin.H{"error": "user has already created a guild"})
 		return
 	}
 
@@ -96,6 +98,10 @@ func (a *API) GuildCreateHandler(c *gin.Context) {
 	if err := a.guildRepo.CreateWithMaster(c.Request.Context(), &guild, &attendee); err != nil {
 		if errors.Is(err, domain.ErrDuplicateEntry) {
 			c.JSON(http.StatusConflict, gin.H{"error": "Guild already exists"})
+			return
+		}
+		if errors.Is(err, domain.ErrGuildLimitReached) {
+			c.JSON(http.StatusConflict, gin.H{"error": "user has already created a guild"})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -242,11 +248,31 @@ func (a *API) GuildTransferLeaderHandler(c *gin.Context) {
 		return
 	}
 
+	callerIDVal, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	callerIDStr, ok := callerIDVal.(string)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user id type"})
+		return
+	}
+	callerID, err := uuid.Parse(callerIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id format"})
+		return
+	}
+
 	// 呼叫 Repo 執行 Transaction 更新
-	err = a.guildRepo.TransferLeader(c.Request.Context(), guildID, req.NewLeaderUserID)
+	err = a.guildRepo.TransferLeader(c.Request.Context(), guildID, callerID, req.NewLeaderUserID)
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Guild not found"})
+			return
+		}
+		if errors.Is(err, domain.ErrNotGuildMaster) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "only the guild master can transfer leadership"})
 			return
 		}
 		if errors.Is(err, domain.ErrNotGuildMember) {
@@ -260,27 +286,57 @@ func (a *API) GuildTransferLeaderHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "leader transferred successfully"})
 }
 
-// @Summary Get active guild invite link
-// @Description Get the currently active invite link for a guild. Returns 200 with null if expired or not found.
-// @Tags guilds
-// @Accept json
-// @Produce json
-// @Param id path string true "Guild ID" format(uuid)
-// @Success 200 {object} domain.GuildInvite "Returns GuildInvite object, or null if no active link exists"
-// @Failure 400 {object} map[string]string "Invalid Guild ID format"
-// @Failure 500 {object} map[string]string "Internal server error"
-// @Router /v1/guilds/{id}/invite-link [get]
 type GuildInviteResponse struct {
 	Code      string     `json:"code"`
 	ExpiresAt *time.Time `json:"expires_at"`
 	CreatedAt time.Time  `json:"created_at"`
 }
 
+// @Summary Get active guild invite link
+// @Description Get the currently active invite link for a guild. Returns 200 with null if expired or not found.
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param id path string true "Guild ID" format(uuid)
+// @Success 200 {object} GuildInviteResponse "Returns the active invite link, or null if expired or not found"
+// @Failure 400 {object} map[string]string "Invalid Guild ID format"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/guilds/{id}/invite-link [get]
 func (a *API) GuildInviteLinkGetHandler(c *gin.Context) {
 	guildIDParam := c.Param("id")
 	guildID, err := uuid.Parse(guildIDParam)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
+		return
+	}
+
+	callerIDVal, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	callerIDStr, ok := callerIDVal.(string)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user id type"})
+		return
+	}
+	callerID, err := uuid.Parse(callerIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id format"})
+		return
+	}
+
+	attendee, err := a.guildAttendeeRepo.GetByGuildAndUser(c.Request.Context(), guildID, callerID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "user is not a member of this guild"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify membership"})
+		return
+	}
+	if attendee == nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": "user is not a member of this guild"})
 		return
 	}
 
@@ -324,16 +380,52 @@ func (a *API) GuildInviteLinkCreateHandler(c *gin.Context) {
 		return
 	}
 
+	callerIDVal, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	callerIDStr, ok := callerIDVal.(string)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user id type"})
+		return
+	}
+	callerID, err := uuid.Parse(callerIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id format"})
+		return
+	}
+
+	attendee, err := a.guildAttendeeRepo.GetByGuildAndUser(c.Request.Context(), guildID, callerID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "user is not a member of this guild"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify membership"})
+		return
+	}
+	if attendee == nil || attendee.Role != domain.GuildAttendeeRoleMaster {
+		c.JSON(http.StatusForbidden, gin.H{"error": "only the guild master can manage invite links"})
+		return
+	}
+
 	var input domain.GuildInvite
-	if err := c.ShouldBindJSON(&input); err != nil && c.Request.ContentLength > 0 {
+	if err := c.ShouldBindJSON(&input); err != nil && !errors.Is(err, io.EOF) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
 		return
 	}
 
 	now := time.Now()
+	const maxTTLSeconds int64 = 31536000 // 1 year
 	var expiresAt *time.Time
-	if input.TTLSeconds != nil && *input.TTLSeconds > 0 {
-		t := now.Add(time.Duration(*input.TTLSeconds) * time.Second)
+	if input.TTLSeconds != nil {
+		ttl := *input.TTLSeconds
+		if ttl <= 0 || ttl > maxTTLSeconds {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "ttl_seconds must be between 1 and 31536000"})
+			return
+		}
+		t := now.Add(time.Duration(ttl) * time.Second)
 		expiresAt = &t
 	}
 
@@ -341,7 +433,7 @@ func (a *API) GuildInviteLinkCreateHandler(c *gin.Context) {
 	newInvite := &domain.GuildInvite{
 		ID:        uuid.New(),
 		GuildID:   guildID,
-		Code:      uuid.New().String()[:8], // Example: take the first 8 characters of the UUID as a simple invite code
+		Code:      strings.ReplaceAll(uuid.New().String(), "-", ""),
 		ExpiresAt: expiresAt,
 		CreatedAt: now,
 	}

--- a/internal/api/guild.go
+++ b/internal/api/guild.go
@@ -260,6 +260,101 @@ func (a *API) GuildTransferLeaderHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "leader transferred successfully"})
 }
 
+// @Summary Get active guild invite link
+// @Description Get the currently active invite link for a guild. Returns 200 with null if expired or not found.
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param id path string true "Guild ID" format(uuid)
+// @Success 200 {object} domain.GuildInvite "Returns GuildInvite object, or null if no active link exists"
+// @Failure 400 {object} map[string]string "Invalid Guild ID format"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/guilds/{id}/invite-link [get]
+type GuildInviteResponse struct {
+	Code      string     `json:"code"`
+	ExpiresAt *time.Time `json:"expires_at"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+func (a *API) GuildInviteLinkGetHandler(c *gin.Context) {
+	guildIDParam := c.Param("id")
+	guildID, err := uuid.Parse(guildIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
+		return
+	}
+
+	invite, err := a.guildRepo.GetActiveInviteByGuildID(c.Request.Context(), guildID, time.Now())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch invite link"})
+		return
+	}
+
+	if invite == nil {
+		c.JSON(http.StatusOK, nil)
+		return
+	}
+
+	// Convert to Response format or return the invite directly.
+	resp := GuildInviteResponse{
+		Code:      invite.Code,
+		ExpiresAt: invite.ExpiresAt,
+		CreatedAt: invite.CreatedAt,
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+// @Summary Create a new guild invite link
+// @Description Creates a new active invite link for a guild and expires any existing active links within a single transaction.
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param id path string true "Guild ID" format(uuid)
+// @Param request body domain.GuildInvite false "Invite Link Options (e.g. {"ttl_seconds": 86400})"
+// @Success 200 {object} domain.GuildInvite
+// @Failure 400 {object} map[string]string "Invalid Guild ID or Request Body"
+// @Failure 500 {object} map[string]string "Internal Server Error"
+// @Router /v1/guilds/{id}/invite-link [post]
+func (a *API) GuildInviteLinkCreateHandler(c *gin.Context) {
+	guildIDParam := c.Param("id")
+	guildID, err := uuid.Parse(guildIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
+		return
+	}
+
+	var input domain.GuildInvite
+	if err := c.ShouldBindJSON(&input); err != nil && c.Request.ContentLength > 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	now := time.Now()
+	var expiresAt *time.Time
+	if input.TTLSeconds != nil && *input.TTLSeconds > 0 {
+		t := now.Add(time.Duration(*input.TTLSeconds) * time.Second)
+		expiresAt = &t
+	}
+
+	// Generate a new invitation link
+	newInvite := &domain.GuildInvite{
+		ID:        uuid.New(),
+		GuildID:   guildID,
+		Code:      uuid.New().String()[:8], // Example: take the first 8 characters of the UUID as a simple invite code
+		ExpiresAt: expiresAt,
+		CreatedAt: now,
+	}
+
+	// In the Transaction: expire old links + create new link
+	if err := a.guildRepo.CreateInviteLinkWithTx(c.Request.Context(), guildID, newInvite, now); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create invite link"})
+		return
+	}
+
+	c.JSON(http.StatusOK, newInvite)
+}
+
 // @Summary Get a guild attendee by ID
 // @Tags guild-attendees
 // @Accept json
@@ -289,42 +384,6 @@ func (a *API) GuildAttendeeGetHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, attendee)
-}
-
-type GuildInviteResponse struct {
-	Code      string     `json:"code"`
-	ExpiresAt *time.Time `json:"expires_at"`
-	CreatedAt time.Time  `json:"created_at"`
-}
-
-func (a *API) GuildInviteLinkGetHandler(c *gin.Context) {
-	guildIDParam := c.Param("id")
-	guildID, err := uuid.Parse(guildIDParam)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
-		return
-	}
-
-	invite, err := a.guildRepo.GetActiveInviteByGuildID(c.Request.Context(), guildID, time.Now())
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch invite link"})
-		return
-	}
-
-	// 若已過期或無 row，invite 為 nil，Go 的 JSON 序列化會自動輸出 200 + null
-	if invite == nil {
-		c.JSON(http.StatusOK, nil)
-		return
-	}
-
-	// 轉成 Response 格式或直接回傳 invite
-	resp := GuildInviteResponse{
-		Code:      invite.Code,
-		ExpiresAt: invite.ExpiresAt,
-		CreatedAt: invite.CreatedAt,
-	}
-
-	c.JSON(http.StatusOK, resp)
 }
 
 // @Summary Create a guild attendee

--- a/internal/api/guild.go
+++ b/internal/api/guild.go
@@ -808,7 +808,6 @@ func (a *API) GuildApplicationRejectHandler(c *gin.Context) {
 	})
 }
 
-// GuildDefaultSlotGetHandler retrieves the default time slot (may be null)
 // @Summary Get guild default slot
 // @Tags guilds
 // @Accept json
@@ -855,7 +854,6 @@ func (a *API) GuildDefaultSlotGetHandler(c *gin.Context) {
 	})
 }
 
-// GuildDefaultSlotUpsertHandler Set or update preset time slots
 // @Summary Upsert guild default slot
 // @Tags guilds
 // @Accept json
@@ -953,7 +951,6 @@ func (a *API) GuildDefaultSlotUpsertHandler(c *gin.Context) {
 	})
 }
 
-// GuildDefaultSlotDeleteHandler deletes the default time slot
 // @Summary Delete guild default slot
 // @Tags guilds
 // @Accept json
@@ -1024,6 +1021,48 @@ func (a *API) GuildDefaultSlotDeleteHandler(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"message": "default slot deleted successfully",
+	})
+}
+
+// @Summary Discover public guilds
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param page query int false "Page number (default 1)" default(1)
+// @Param page_size query int false "Page size (default 10, max 100)" default(10)
+// @Success 200 {object} map[string]interface{} "Success"
+// @Failure 400 {object} map[string]string "Invalid query parameters"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/guilds/discover [get]
+type GuildDiscoverReq struct {
+	Page     int `form:"page,default=1" binding:"omitempty,gte=1"`
+	PageSize int `form:"page_size,default=10" binding:"omitempty,gte=1,lte=100"`
+}
+
+func (a *API) GuildDiscoverHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var req GuildDiscoverReq
+	if err := c.ShouldBindQuery(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid query parameters: " + err.Error()})
+		return
+	}
+	if req.Page <= 0 {
+		req.Page = 1
+	}
+	if req.PageSize <= 0 {
+		req.PageSize = 10
+	}
+
+	// Discover public guilds with pagination
+	result, err := a.guildRepo.Discover(ctx, req.Page, req.PageSize)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to discover guilds"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data": result,
 	})
 }
 

--- a/internal/api/guild.go
+++ b/internal/api/guild.go
@@ -52,13 +52,47 @@ func (a *API) GuildGetHandler(c *gin.Context) {
 // @Failure 500 {object} map[string]string
 // @Router /v1/guilds [post]
 func (a *API) GuildCreateHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	userIDVal, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	userIDStr, ok := userIDVal.(string)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user id type"})
+		return
+	}
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id format"})
+		return
+	}
+
+	// 檢查 Caller 已建立公會數
+	count, err := a.guildRepo.CountMasterGuildsByUserID(ctx, userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if count >= 1 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user has already created a guild"})
+		return
+	}
+
 	var guild domain.Guild
 	if err := c.ShouldBindJSON(&guild); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	if err := a.guildRepo.Create(c.Request.Context(), &guild); err != nil {
+	// 4. 建立會長 Attendee 實體
+	attendee := domain.GuildAttendee{
+		UserID: userID,
+		Role:   domain.GuildAttendeeRoleMaster,
+	}
+
+	if err := a.guildRepo.CreateWithMaster(c.Request.Context(), &guild, &attendee); err != nil {
 		if errors.Is(err, domain.ErrDuplicateEntry) {
 			c.JSON(http.StatusConflict, gin.H{"error": "Guild already exists"})
 			return

--- a/internal/api/guild.go
+++ b/internal/api/guild.go
@@ -86,7 +86,7 @@ func (a *API) GuildCreateHandler(c *gin.Context) {
 		return
 	}
 
-	// 4. 建立會長 Attendee 實體
+	// 建立 Attendee 實體
 	attendee := domain.GuildAttendee{
 		UserID: userID,
 		Role:   domain.GuildAttendeeRoleMaster,
@@ -116,6 +116,12 @@ func (a *API) GuildCreateHandler(c *gin.Context) {
 // @Failure 409 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /v1/guilds/{id} [put]
+
+type UpdateGuildRequest struct {
+	Name        *string `json:"name" binding:"omitempty,max=100"`
+	Description *string `json:"description" binding:"omitempty,max=500"`
+}
+
 func (a *API) GuildUpdateHandler(c *gin.Context) {
 	idStr := c.Param("id")
 	id, err := uuid.Parse(idStr)
@@ -124,7 +130,7 @@ func (a *API) GuildUpdateHandler(c *gin.Context) {
 		return
 	}
 
-	_, err = a.guildRepo.GetByID(c.Request.Context(), id)
+	guild, err := a.guildRepo.GetByID(c.Request.Context(), id)
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Guild not found"})
@@ -134,14 +140,20 @@ func (a *API) GuildUpdateHandler(c *gin.Context) {
 		return
 	}
 
-	var guild domain.Guild
-	if err := c.ShouldBindJSON(&guild); err != nil {
+	var req UpdateGuildRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	guild.ID = id
-	if err := a.guildRepo.Update(c.Request.Context(), &guild); err != nil {
+	if req.Name != nil {
+		guild.Name = *req.Name
+	}
+	if req.Description != nil {
+		guild.Description = *req.Description
+	}
+
+	if err := a.guildRepo.Update(c.Request.Context(), guild); err != nil {
 		if errors.Is(err, domain.ErrDuplicateEntry) {
 			c.JSON(http.StatusConflict, gin.H{"error": "Guild already exists"})
 			return

--- a/internal/api/guild.go
+++ b/internal/api/guild.go
@@ -855,6 +855,178 @@ func (a *API) GuildDefaultSlotGetHandler(c *gin.Context) {
 	})
 }
 
+// GuildDefaultSlotUpsertHandler Set or update preset time slots
+// @Summary Upsert guild default slot
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param id path string true "Guild ID (UUID)" format(uuid)
+// @Param request body domain.GuildDefaultSlotUpsertReq true "Upsert Request Body"
+// @Success 200 {object} map[string]interface{} "Success"
+// @Failure 400 {object} map[string]string "Invalid request body or guild_id"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Failure 403 {object} map[string]string "Forbidden: only master can manage default slot"
+// @Failure 404 {object} map[string]string "Guild not found"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/guilds/{id}/default-slot [put]
+type GuildDefaultSlotUpsertReq struct {
+	DayOfWeek int    `json:"day_of_week" binding:"gte=0,lte=6"`
+	StartTime string `json:"start_time" binding:"required"`
+	EndTime   string `json:"end_time" binding:"required"`
+}
+
+func (a *API) GuildDefaultSlotUpsertHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	guildID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
+		return
+	}
+
+	var req GuildDefaultSlotUpsertReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body: " + err.Error()})
+		return
+	}
+
+	// Check the caller's identity
+	callerIDVal, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	callerID, ok := callerIDVal.(uuid.UUID)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user ID type in context"})
+		return
+	}
+
+	// Check if the caller is the member of the guild
+	callerAttendee, err := a.guildAttendeeRepo.GetByGuildAndUser(ctx, guildID, callerID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: you are not a member of this guild"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify caller permission"})
+		return
+	}
+	// Check if the caller is the master of the guild
+	if callerAttendee.LeftAt != nil || callerAttendee.Role != domain.GuildAttendeeRoleMaster {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: only guild master can manage default slot"})
+		return
+	}
+
+	// Check if the guild exists
+	_, err = a.guildRepo.GetByID(ctx, guildID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "guild not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query guild"})
+		return
+	}
+
+	slot := &domain.GuildDefaultSlot{
+		ID:        uuid.New(),
+		GuildID:   guildID,
+		DayOfWeek: req.DayOfWeek,
+		StartTime: req.StartTime,
+		EndTime:   req.EndTime,
+	}
+
+	if err := a.defaultSlotRepo.Upsert(ctx, slot); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to upsert default slot"})
+		return
+	}
+
+	// Requery the latest slot records and return
+	latestSlot, err := a.defaultSlotRepo.GetByGuildID(ctx, guildID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch updated default slot"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data": latestSlot,
+	})
+}
+
+// GuildDefaultSlotDeleteHandler deletes the default time slot
+// @Summary Delete guild default slot
+// @Tags guilds
+// @Accept json
+// @Produce json
+// @Param id path string true "Guild ID (UUID)" format(uuid)
+// @Success 200 {object} map[string]string "Success"
+// @Failure 400 {object} map[string]string "Invalid guild_id"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Failure 403 {object} map[string]string "Forbidden: only master can delete default slot"
+// @Failure 404 {object} map[string]string "Guild or default slot not found"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /v1/guilds/{id}/default-slot [delete]
+func (a *API) GuildDefaultSlotDeleteHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+	guildID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid guild_id"})
+		return
+	}
+
+	callerIDVal, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	callerID, ok := callerIDVal.(uuid.UUID)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid user ID type in context"})
+		return
+	}
+	// Check if the caller is the member of the guild
+	callerAttendee, err := a.guildAttendeeRepo.GetByGuildAndUser(ctx, guildID, callerID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: you are not a member of this guild"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify caller permission"})
+		return
+	}
+	// Check if the caller is the master of the guild
+	if callerAttendee.LeftAt != nil || callerAttendee.Role != domain.GuildAttendeeRoleMaster {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden: only guild master can delete default slot"})
+		return
+	}
+
+	// Check if the guild exists
+	_, err = a.guildRepo.GetByID(ctx, guildID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "guild not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query guild"})
+		return
+	}
+
+	// Perform deletion
+	err = a.defaultSlotRepo.DeleteByGuildID(ctx, guildID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "default slot not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete default slot"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "default slot deleted successfully",
+	})
+}
+
 // @Summary Get a guild attendee by ID
 // @Tags guild-attendees
 // @Accept json

--- a/internal/api/guild_test.go
+++ b/internal/api/guild_test.go
@@ -1,0 +1,410 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"jpcorrect-backend/internal/domain"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockGuildRepo implements domain.GuildRepository by embedding the interface
+// and overriding only the methods exercised by the handlers under test.
+// Any non-overridden method that is accidentally called will panic on the nil
+// embedded interface — acceptable for these focused handler tests.
+type mockGuildRepo struct {
+	domain.GuildRepository
+
+	transferLeaderCalls []transferLeaderCall
+	transferLeaderErr   error
+
+	activeInviteCalls int
+	activeInvite      *domain.GuildInvite
+	activeInviteErr   error
+
+	createInviteLinkCalls []createInviteLinkCall
+	createInviteLinkErr   error
+}
+
+type transferLeaderCall struct {
+	guildID, callerID, newLeaderID uuid.UUID
+}
+
+type createInviteLinkCall struct {
+	guildID uuid.UUID
+	invite  *domain.GuildInvite
+}
+
+func (m *mockGuildRepo) TransferLeader(_ context.Context, guildID, callerID, newLeaderID uuid.UUID) error {
+	m.transferLeaderCalls = append(m.transferLeaderCalls, transferLeaderCall{guildID, callerID, newLeaderID})
+	return m.transferLeaderErr
+}
+
+func (m *mockGuildRepo) GetActiveInviteByGuildID(_ context.Context, _ uuid.UUID, _ time.Time) (*domain.GuildInvite, error) {
+	m.activeInviteCalls++
+	return m.activeInvite, m.activeInviteErr
+}
+
+func (m *mockGuildRepo) CreateInviteLinkWithTx(_ context.Context, guildID uuid.UUID, newInvite *domain.GuildInvite, _ time.Time) error {
+	m.createInviteLinkCalls = append(m.createInviteLinkCalls, createInviteLinkCall{guildID: guildID, invite: newInvite})
+	return m.createInviteLinkErr
+}
+
+// mockAttendeeRepo implements domain.GuildAttendeeRepository by embedding the
+// interface and overriding only GetByGuildAndUser, the single method the
+// handlers under test call on it.
+type mockAttendeeRepo struct {
+	domain.GuildAttendeeRepository
+
+	getByGuildAndUserResult *domain.GuildAttendee
+	getByGuildAndUserErr    error
+	getByGuildAndUserCalls  []getByGuildAndUserCall
+}
+
+type getByGuildAndUserCall struct {
+	guildID, userID uuid.UUID
+}
+
+func (m *mockAttendeeRepo) GetByGuildAndUser(_ context.Context, guildID, userID uuid.UUID) (*domain.GuildAttendee, error) {
+	m.getByGuildAndUserCalls = append(m.getByGuildAndUserCalls, getByGuildAndUserCall{guildID, userID})
+	return m.getByGuildAndUserResult, m.getByGuildAndUserErr
+}
+
+func newTestAPI() (*API, *mockGuildRepo, *mockAttendeeRepo) {
+	gRepo := &mockGuildRepo{}
+	aRepo := &mockAttendeeRepo{}
+	api := &API{guildRepo: gRepo, guildAttendeeRepo: aRepo}
+	return api, gRepo, aRepo
+}
+
+// invokeHandler mounts handler on a fresh gin engine. The UUID segment of path
+// is converted to the :id route param (the handlers read c.Param("id")). When
+// userID is non-nil it is injected into the gin context as a string, exactly
+// like AuthMiddleware does (c.Set("userID", claims.Subject)); when nil, no
+// value is set so c.Get("userID") returns (nil, false) → 401.
+//
+// The HTTP method is inferred: POST when a body is provided (even an empty
+// one), GET otherwise — matching the handlers under test.
+func invokeHandler(t *testing.T, handler gin.HandlerFunc, path string, userID *uuid.UUID, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	parts := strings.Split(path, "/")
+	for i, p := range parts {
+		if _, err := uuid.Parse(p); err == nil {
+			parts[i] = ":id"
+		}
+	}
+	pattern := strings.Join(parts, "/")
+
+	method := http.MethodGet
+	if body != nil {
+		method = http.MethodPost
+	}
+
+	r := gin.New()
+	r.Handle(method, pattern, func(c *gin.Context) {
+		if userID != nil {
+			c.Set("userID", userID.String())
+		}
+		handler(c)
+	})
+
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, path, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+type transferLeaderBody struct {
+	NewLeaderUserID uuid.UUID `json:"new_leader_user_id"`
+}
+
+type inviteLinkBody struct {
+	TTLSeconds int64 `json:"ttl_seconds"`
+}
+
+func TestGuildTransferLeaderHandler(t *testing.T) {
+	callerID := uuid.New()
+	newLeaderID := uuid.New()
+	transferPath := func(guildID uuid.UUID) string {
+		return "/v1/guilds/" + guildID.String() + "/transfer-leader"
+	}
+
+	t.Run("no userID in context → 401", func(t *testing.T) {
+		api, gRepo, _ := newTestAPI()
+		body, err := json.Marshal(transferLeaderBody{NewLeaderUserID: newLeaderID})
+		assert.NoError(t, err)
+
+		rec := invokeHandler(t, api.GuildTransferLeaderHandler, transferPath(uuid.New()), nil, body)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Contains(t, rec.Body.String(), "unauthorized")
+		assert.Empty(t, gRepo.transferLeaderCalls)
+	})
+
+	t.Run("caller is not a member → 403", func(t *testing.T) {
+		api, gRepo, _ := newTestAPI()
+		guildID := uuid.New()
+		// The caller-membership/master check runs inside TransferLeader (repo
+		// layer): a caller without a membership row is rejected with
+		// ErrNotGuildMaster, which the handler maps to 403.
+		gRepo.transferLeaderErr = domain.ErrNotGuildMaster
+		body, err := json.Marshal(transferLeaderBody{NewLeaderUserID: newLeaderID})
+		assert.NoError(t, err)
+
+		rec := invokeHandler(t, api.GuildTransferLeaderHandler, transferPath(guildID), &callerID, body)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Contains(t, rec.Body.String(), "only the guild master can transfer leadership")
+		// the handler delegated the authz check to the repo — the call was made
+		if assert.Len(t, gRepo.transferLeaderCalls, 1) {
+			assert.Equal(t, callerID, gRepo.transferLeaderCalls[0].callerID)
+		}
+	})
+
+	t.Run("caller is member but not master → 403", func(t *testing.T) {
+		api, gRepo, _ := newTestAPI()
+		guildID := uuid.New()
+		// Same handler branch: TransferLeader rejects a member (non-master)
+		// caller with ErrNotGuildMaster → 403.
+		gRepo.transferLeaderErr = domain.ErrNotGuildMaster
+		body, err := json.Marshal(transferLeaderBody{NewLeaderUserID: newLeaderID})
+		assert.NoError(t, err)
+
+		rec := invokeHandler(t, api.GuildTransferLeaderHandler, transferPath(guildID), &callerID, body)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Contains(t, rec.Body.String(), "only the guild master can transfer leadership")
+		if assert.Len(t, gRepo.transferLeaderCalls, 1) {
+			assert.Equal(t, callerID, gRepo.transferLeaderCalls[0].callerID)
+		}
+	})
+
+	t.Run("caller is master, new leader not a member → 400", func(t *testing.T) {
+		api, gRepo, _ := newTestAPI()
+		guildID := uuid.New()
+		gRepo.transferLeaderErr = domain.ErrNotGuildMember
+		body, err := json.Marshal(transferLeaderBody{NewLeaderUserID: newLeaderID})
+		assert.NoError(t, err)
+
+		rec := invokeHandler(t, api.GuildTransferLeaderHandler, transferPath(guildID), &callerID, body)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "New leader must be a member of the guild")
+		if assert.Len(t, gRepo.transferLeaderCalls, 1) {
+			assert.Equal(t, newLeaderID, gRepo.transferLeaderCalls[0].newLeaderID)
+		}
+	})
+
+	t.Run("caller is master, guild not found → 404", func(t *testing.T) {
+		api, gRepo, _ := newTestAPI()
+		gRepo.transferLeaderErr = domain.ErrNotFound
+		body, err := json.Marshal(transferLeaderBody{NewLeaderUserID: newLeaderID})
+		assert.NoError(t, err)
+
+		rec := invokeHandler(t, api.GuildTransferLeaderHandler, transferPath(uuid.New()), &callerID, body)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		assert.Contains(t, rec.Body.String(), "Guild not found")
+	})
+
+	t.Run("caller is master, success → 200", func(t *testing.T) {
+		api, gRepo, _ := newTestAPI()
+		guildID := uuid.New()
+		body, err := json.Marshal(transferLeaderBody{NewLeaderUserID: newLeaderID})
+		assert.NoError(t, err)
+
+		rec := invokeHandler(t, api.GuildTransferLeaderHandler, transferPath(guildID), &callerID, body)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), "leader transferred successfully")
+		if assert.Len(t, gRepo.transferLeaderCalls, 1) {
+			assert.Equal(t, guildID, gRepo.transferLeaderCalls[0].guildID)
+			assert.Equal(t, callerID, gRepo.transferLeaderCalls[0].callerID)
+			assert.Equal(t, newLeaderID, gRepo.transferLeaderCalls[0].newLeaderID)
+		}
+	})
+}
+
+func TestGuildInviteLinkGetHandler(t *testing.T) {
+	callerID := uuid.New()
+	getPath := func(guildID uuid.UUID) string {
+		return "/v1/guilds/" + guildID.String() + "/invite-link"
+	}
+
+	t.Run("no userID → 401", func(t *testing.T) {
+		api, _, aRepo := newTestAPI()
+
+		rec := invokeHandler(t, api.GuildInviteLinkGetHandler, getPath(uuid.New()), nil, nil)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Contains(t, rec.Body.String(), "unauthorized")
+		assert.Empty(t, aRepo.getByGuildAndUserCalls)
+	})
+
+	t.Run("non-member → 403", func(t *testing.T) {
+		api, gRepo, aRepo := newTestAPI()
+		guildID := uuid.New()
+		aRepo.getByGuildAndUserErr = domain.ErrNotFound
+
+		rec := invokeHandler(t, api.GuildInviteLinkGetHandler, getPath(guildID), &callerID, nil)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Contains(t, rec.Body.String(), "user is not a member of this guild")
+		if assert.Len(t, aRepo.getByGuildAndUserCalls, 1) {
+			assert.Equal(t, guildID, aRepo.getByGuildAndUserCalls[0].guildID)
+			assert.Equal(t, callerID, aRepo.getByGuildAndUserCalls[0].userID)
+		}
+		// membership check failed → the invite must never be queried
+		assert.Zero(t, gRepo.activeInviteCalls)
+	})
+
+	t.Run("member success → 200 with body", func(t *testing.T) {
+		api, gRepo, aRepo := newTestAPI()
+		guildID := uuid.New()
+		aRepo.getByGuildAndUserResult = &domain.GuildAttendee{Role: domain.GuildAttendeeRoleMaster}
+		expiresAt := time.Now().Add(time.Hour)
+		gRepo.activeInvite = &domain.GuildInvite{
+			Code:      "abc123",
+			ExpiresAt: &expiresAt,
+			CreatedAt: time.Now(),
+		}
+
+		rec := invokeHandler(t, api.GuildInviteLinkGetHandler, getPath(guildID), &callerID, nil)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), `"code":"abc123"`)
+		if assert.Len(t, aRepo.getByGuildAndUserCalls, 1) {
+			assert.Equal(t, guildID, aRepo.getByGuildAndUserCalls[0].guildID)
+			assert.Equal(t, callerID, aRepo.getByGuildAndUserCalls[0].userID)
+		}
+		assert.Equal(t, 1, gRepo.activeInviteCalls)
+	})
+
+	t.Run("member but no active invite → 200 null", func(t *testing.T) {
+		api, gRepo, aRepo := newTestAPI()
+		aRepo.getByGuildAndUserResult = &domain.GuildAttendee{Role: domain.GuildAttendeeRoleMaster}
+
+		rec := invokeHandler(t, api.GuildInviteLinkGetHandler, getPath(uuid.New()), &callerID, nil)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "null", strings.TrimSpace(rec.Body.String()))
+		assert.Equal(t, 1, gRepo.activeInviteCalls)
+	})
+}
+
+func TestGuildInviteLinkCreateHandler(t *testing.T) {
+	callerID := uuid.New()
+	createPath := func(guildID uuid.UUID) string {
+		return "/v1/guilds/" + guildID.String() + "/invite-link"
+	}
+	codePattern := `^[0-9a-f]{32}$`
+
+	t.Run("non-member → 403", func(t *testing.T) {
+		api, gRepo, aRepo := newTestAPI()
+		aRepo.getByGuildAndUserErr = domain.ErrNotFound
+
+		rec := invokeHandler(t, api.GuildInviteLinkCreateHandler, createPath(uuid.New()), &callerID, []byte(`{"ttl_seconds":3600}`))
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Contains(t, rec.Body.String(), "user is not a member of this guild")
+		assert.Empty(t, gRepo.createInviteLinkCalls)
+	})
+
+	t.Run("member not master → 403", func(t *testing.T) {
+		api, gRepo, aRepo := newTestAPI()
+		aRepo.getByGuildAndUserResult = &domain.GuildAttendee{Role: domain.GuildAttendeeRoleMember}
+
+		rec := invokeHandler(t, api.GuildInviteLinkCreateHandler, createPath(uuid.New()), &callerID, []byte(`{"ttl_seconds":3600}`))
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Contains(t, rec.Body.String(), "only the guild master can manage invite links")
+		assert.Empty(t, gRepo.createInviteLinkCalls)
+	})
+
+	t.Run("master, TTL <= 0 → 400", func(t *testing.T) {
+		api, gRepo, aRepo := newTestAPI()
+		aRepo.getByGuildAndUserResult = &domain.GuildAttendee{Role: domain.GuildAttendeeRoleMaster}
+		body, err := json.Marshal(inviteLinkBody{TTLSeconds: -5})
+		assert.NoError(t, err)
+
+		rec := invokeHandler(t, api.GuildInviteLinkCreateHandler, createPath(uuid.New()), &callerID, body)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "ttl_seconds must be between 1 and 31536000")
+		assert.Empty(t, gRepo.createInviteLinkCalls)
+	})
+
+	t.Run("master, TTL too large → 400", func(t *testing.T) {
+		api, gRepo, aRepo := newTestAPI()
+		aRepo.getByGuildAndUserResult = &domain.GuildAttendee{Role: domain.GuildAttendeeRoleMaster}
+		body, err := json.Marshal(inviteLinkBody{TTLSeconds: 999999999})
+		assert.NoError(t, err)
+
+		rec := invokeHandler(t, api.GuildInviteLinkCreateHandler, createPath(uuid.New()), &callerID, body)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "ttl_seconds must be between 1 and 31536000")
+		assert.Empty(t, gRepo.createInviteLinkCalls)
+	})
+
+	t.Run("master, valid TTL → 200", func(t *testing.T) {
+		api, gRepo, aRepo := newTestAPI()
+		guildID := uuid.New()
+		aRepo.getByGuildAndUserResult = &domain.GuildAttendee{Role: domain.GuildAttendeeRoleMaster}
+		body, err := json.Marshal(inviteLinkBody{TTLSeconds: 3600})
+		assert.NoError(t, err)
+
+		rec := invokeHandler(t, api.GuildInviteLinkCreateHandler, createPath(guildID), &callerID, body)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp struct {
+			Code      string     `json:"code"`
+			ExpiresAt *time.Time `json:"expires_at"`
+		}
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Regexp(t, codePattern, resp.Code)
+		assert.NotNil(t, resp.ExpiresAt)
+		if assert.Len(t, gRepo.createInviteLinkCalls, 1) {
+			assert.Equal(t, guildID, gRepo.createInviteLinkCalls[0].guildID)
+			assert.NotNil(t, gRepo.createInviteLinkCalls[0].invite.ExpiresAt)
+			assert.Len(t, gRepo.createInviteLinkCalls[0].invite.Code, 32)
+		}
+	})
+
+	t.Run("master, empty body → 200 permanent", func(t *testing.T) {
+		api, gRepo, aRepo := newTestAPI()
+		aRepo.getByGuildAndUserResult = &domain.GuildAttendee{Role: domain.GuildAttendeeRoleMaster}
+
+		rec := invokeHandler(t, api.GuildInviteLinkCreateHandler, createPath(uuid.New()), &callerID, []byte{})
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp struct {
+			Code      string     `json:"code"`
+			ExpiresAt *time.Time `json:"expires_at"`
+		}
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Regexp(t, codePattern, resp.Code)
+		assert.Nil(t, resp.ExpiresAt)
+		if assert.Len(t, gRepo.createInviteLinkCalls, 1) {
+			assert.Nil(t, gRepo.createInviteLinkCalls[0].invite.ExpiresAt)
+		}
+	})
+}

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -31,6 +31,7 @@ func Execute() {
 		&domain.EventAttendee{},
 		&domain.Transcript{},
 		&domain.Mistake{},
+		&domain.GuildInvite{},
 	); err != nil {
 		log.Fatalf("failed to run auto migrate: %v", err)
 	}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -33,4 +33,6 @@ var (
 	ErrDuplicateEntry    = errors.New("duplicate entry")
 	ErrHasRelatedRecords = errors.New("record has related records")
 	ErrNotGuildMember    = errors.New("user is not a member of this guild")
+	ErrNotGuildMaster    = errors.New("user is not the master of this guild")
+	ErrGuildLimitReached = errors.New("user has already created a guild")
 )

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -32,4 +32,5 @@ var (
 	ErrNotFound          = errors.New("record not found")
 	ErrDuplicateEntry    = errors.New("duplicate entry")
 	ErrHasRelatedRecords = errors.New("record has related records")
+	ErrNotGuildMember    = errors.New("user is not a member of this guild")
 )

--- a/internal/domain/guild.go
+++ b/internal/domain/guild.go
@@ -30,14 +30,25 @@ type Guild struct {
 	DeletedAt   gorm.DeletedAt `gorm:"index" json:"deleted_at"`
 }
 
+type GuildInvite struct {
+	ID        uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	GuildID   uuid.UUID  `gorm:"type:uuid;not null;index" json:"guild_id"`
+	Code      string     `gorm:"type:varchar(32);uniqueIndex;not null" json:"code"`
+	ExpiresAt *time.Time `json:"expires_at"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
 type GuildRepository interface {
 	GetByID(ctx context.Context, guildID uuid.UUID) (*Guild, error)
-	CreateWithMaster(ctx context.Context, guild *Guild, attendee *GuildAttendee) error
 	CountMasterGuildsByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
+	CreateWithMaster(ctx context.Context, guild *Guild, attendee *GuildAttendee) error
+	TransferLeader(ctx context.Context, guildID uuid.UUID, newLeaderID uuid.UUID) error
 
 	Create(ctx context.Context, guild *Guild) error
 	Update(ctx context.Context, guild *Guild) error
 	Delete(ctx context.Context, guildID uuid.UUID) error
+
+	GetActiveInviteByGuildID(ctx context.Context, guildID uuid.UUID, now time.Time) (*GuildInvite, error)
 }
 
 // GuildAttendee represents a member of a guild.

--- a/internal/domain/guild.go
+++ b/internal/domain/guild.go
@@ -39,6 +39,13 @@ type GuildInvite struct {
 	TTLSeconds *int64     `gorm:"-" json:"ttl_seconds,omitempty"`
 }
 
+type GuildDiscoverResult struct {
+	Items      []*Guild `json:"items"`
+	TotalCount int64    `json:"total_count"`
+	Page       int      `json:"page"`
+	PageSize   int      `json:"page_size"`
+}
+
 type GuildRepository interface {
 	GetByID(ctx context.Context, guildID uuid.UUID) (*Guild, error)
 	CountMasterGuildsByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
@@ -51,6 +58,7 @@ type GuildRepository interface {
 
 	GetActiveInviteByGuildID(ctx context.Context, guildID uuid.UUID, now time.Time) (*GuildInvite, error)
 	CreateInviteLinkWithTx(ctx context.Context, guildID uuid.UUID, newInvite *GuildInvite, now time.Time) error
+	Discover(ctx context.Context, page, pageSize int) (*GuildDiscoverResult, error)
 }
 
 // GuildAttendee represents a member of a guild.

--- a/internal/domain/guild.go
+++ b/internal/domain/guild.go
@@ -43,7 +43,7 @@ type GuildRepository interface {
 	GetByID(ctx context.Context, guildID uuid.UUID) (*Guild, error)
 	CountMasterGuildsByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
 	CreateWithMaster(ctx context.Context, guild *Guild, attendee *GuildAttendee) error
-	TransferLeader(ctx context.Context, guildID uuid.UUID, newLeaderID uuid.UUID) error
+	TransferLeader(ctx context.Context, guildID uuid.UUID, callerID uuid.UUID, newLeaderID uuid.UUID) error
 
 	Create(ctx context.Context, guild *Guild) error
 	Update(ctx context.Context, guild *Guild) error
@@ -68,6 +68,7 @@ type GuildAttendeeRepository interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*GuildAttendee, error)
 	GetByGuildID(ctx context.Context, guildID uuid.UUID) ([]*GuildAttendee, error)
 	GetByUserID(ctx context.Context, userID uuid.UUID) ([]*GuildAttendee, error)
+	GetByGuildAndUser(ctx context.Context, guildID uuid.UUID, userID uuid.UUID) (*GuildAttendee, error)
 
 	Create(ctx context.Context, attendee *GuildAttendee) error
 	Update(ctx context.Context, attendee *GuildAttendee) error

--- a/internal/domain/guild.go
+++ b/internal/domain/guild.go
@@ -101,3 +101,18 @@ type GuildApplicationRepository interface {
 	Create(ctx context.Context, app *GuildApplication) error
 	Update(ctx context.Context, app *GuildApplication) error
 }
+
+type GuildDefaultSlot struct {
+	ID        uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	GuildID   uuid.UUID      `gorm:"type:uuid;not null;uniqueIndex" json:"guild_id"`
+	DayOfWeek int            `json:"day_of_week"`
+	StartTime string         `gorm:"type:varchar(5)" json:"start_time"`
+	EndTime   string         `gorm:"type:varchar(5)" json:"end_time"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"deleted_at,omitempty"`
+}
+
+type GuildDefaultSlotRepository interface {
+	GetByGuildID(ctx context.Context, guildID uuid.UUID) (*GuildDefaultSlot, error)
+}

--- a/internal/domain/guild.go
+++ b/internal/domain/guild.go
@@ -32,6 +32,8 @@ type Guild struct {
 
 type GuildRepository interface {
 	GetByID(ctx context.Context, guildID uuid.UUID) (*Guild, error)
+	CreateWithMaster(ctx context.Context, guild *Guild, attendee *GuildAttendee) error
+	CountMasterGuildsByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
 
 	Create(ctx context.Context, guild *Guild) error
 	Update(ctx context.Context, guild *Guild) error

--- a/internal/domain/guild.go
+++ b/internal/domain/guild.go
@@ -74,3 +74,26 @@ type GuildAttendeeRepository interface {
 	Update(ctx context.Context, attendee *GuildAttendee) error
 	Delete(ctx context.Context, id uuid.UUID) error
 }
+
+type GuildApplicationStatus string
+
+const (
+	GuildApplicationStatusPending  GuildApplicationStatus = "pending"
+	GuildApplicationStatusApproved GuildApplicationStatus = "approved"
+	GuildApplicationStatusRejected GuildApplicationStatus = "rejected"
+)
+
+type GuildApplication struct {
+	ID        uuid.UUID              `gorm:"type:uuid;primaryKey" json:"id"`
+	GuildID   uuid.UUID              `gorm:"type:uuid;not null;index" json:"guild_id"`
+	UserID    uuid.UUID              `gorm:"type:uuid;not null;index" json:"user_id"`
+	Status    GuildApplicationStatus `gorm:"type:varchar(20);default:'pending';not null" json:"status"`
+	CreatedAt time.Time              `json:"created_at"`
+	UpdatedAt time.Time              `json:"updated_at"`
+}
+
+type GuildApplicationRepository interface {
+	Create(ctx context.Context, app *GuildApplication) error
+	GetPendingByGuildAndUser(ctx context.Context, guildID, userID uuid.UUID) (*GuildApplication, error)
+	ListPendingByGuildID(ctx context.Context, guildID uuid.UUID) ([]*GuildApplication, error)
+}

--- a/internal/domain/guild.go
+++ b/internal/domain/guild.go
@@ -31,11 +31,12 @@ type Guild struct {
 }
 
 type GuildInvite struct {
-	ID        uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
-	GuildID   uuid.UUID  `gorm:"type:uuid;not null;index" json:"guild_id"`
-	Code      string     `gorm:"type:varchar(32);uniqueIndex;not null" json:"code"`
-	ExpiresAt *time.Time `json:"expires_at"`
-	CreatedAt time.Time  `json:"created_at"`
+	ID         uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	GuildID    uuid.UUID  `gorm:"type:uuid;not null;index" json:"guild_id"`
+	Code       string     `gorm:"type:varchar(32);uniqueIndex;not null" json:"code"`
+	ExpiresAt  *time.Time `json:"expires_at"`
+	CreatedAt  time.Time  `json:"created_at"`
+	TTLSeconds *int64     `gorm:"-" json:"ttl_seconds,omitempty"`
 }
 
 type GuildRepository interface {
@@ -49,6 +50,7 @@ type GuildRepository interface {
 	Delete(ctx context.Context, guildID uuid.UUID) error
 
 	GetActiveInviteByGuildID(ctx context.Context, guildID uuid.UUID, now time.Time) (*GuildInvite, error)
+	CreateInviteLinkWithTx(ctx context.Context, guildID uuid.UUID, newInvite *GuildInvite, now time.Time) error
 }
 
 // GuildAttendee represents a member of a guild.

--- a/internal/domain/guild.go
+++ b/internal/domain/guild.go
@@ -93,7 +93,11 @@ type GuildApplication struct {
 }
 
 type GuildApplicationRepository interface {
-	Create(ctx context.Context, app *GuildApplication) error
+	GetByID(ctx context.Context, appID uuid.UUID) (*GuildApplication, error)
 	GetPendingByGuildAndUser(ctx context.Context, guildID, userID uuid.UUID) (*GuildApplication, error)
 	ListPendingByGuildID(ctx context.Context, guildID uuid.UUID) ([]*GuildApplication, error)
+	ApproveWithTx(ctx context.Context, app *GuildApplication, newAttendee *GuildAttendee) error
+
+	Create(ctx context.Context, app *GuildApplication) error
+	Update(ctx context.Context, app *GuildApplication) error
 }

--- a/internal/domain/guild.go
+++ b/internal/domain/guild.go
@@ -115,4 +115,7 @@ type GuildDefaultSlot struct {
 
 type GuildDefaultSlotRepository interface {
 	GetByGuildID(ctx context.Context, guildID uuid.UUID) (*GuildDefaultSlot, error)
+	DeleteByGuildID(ctx context.Context, guildID uuid.UUID) error
+
+	Upsert(ctx context.Context, slot *GuildDefaultSlot) error
 }

--- a/internal/repository/gorm_guild.go
+++ b/internal/repository/gorm_guild.go
@@ -279,11 +279,13 @@ func NewGuildApplicationRepository(db *gorm.DB) domain.GuildApplicationRepositor
 	return &guildApplicationRepository{db: db}
 }
 
-func (r *guildApplicationRepository) Create(ctx context.Context, app *domain.GuildApplication) error {
-	if app.ID == uuid.Nil {
-		app.ID = uuid.New()
+func (r *guildApplicationRepository) GetByID(ctx context.Context, appID uuid.UUID) (*domain.GuildApplication, error) {
+	var app domain.GuildApplication
+	err := r.db.WithContext(ctx).First(&app, "id = ?", appID).Error
+	if err != nil {
+		return nil, MapGormError(err)
 	}
-	return MapGormError(r.db.WithContext(ctx).Create(app).Error)
+	return &app, nil
 }
 
 func (r *guildApplicationRepository) GetPendingByGuildAndUser(ctx context.Context, guildID, userID uuid.UUID) (*domain.GuildApplication, error) {
@@ -309,4 +311,48 @@ func (r *guildApplicationRepository) ListPendingByGuildID(ctx context.Context, g
 		return nil, MapGormError(err)
 	}
 	return apps, nil
+}
+
+func (r *guildApplicationRepository) ApproveWithTx(ctx context.Context, app *domain.GuildApplication, newAttendee *domain.GuildAttendee) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		now := time.Now()
+		app.Status = domain.GuildApplicationStatusApproved
+		app.UpdatedAt = now
+		if err := tx.Save(app).Error; err != nil {
+			return err
+		}
+
+		if newAttendee.ID == uuid.Nil {
+			newAttendee.ID = uuid.New()
+		}
+		newAttendee.JoinedAt = &now
+		if err := tx.Create(newAttendee).Error; err != nil {
+			return err
+		}
+
+		// Reject all pending from this applicant under other guilds
+		err := tx.Model(&domain.GuildApplication{}).
+			Where("user_id = ? AND status = ? AND id != ?", app.UserID, domain.GuildApplicationStatusPending, app.ID).
+			Updates(map[string]interface{}{
+				"status":     domain.GuildApplicationStatusRejected,
+				"updated_at": now,
+			}).Error
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (r *guildApplicationRepository) Create(ctx context.Context, app *domain.GuildApplication) error {
+	if app.ID == uuid.Nil {
+		app.ID = uuid.New()
+	}
+	return MapGormError(r.db.WithContext(ctx).Create(app).Error)
+}
+
+func (r *guildApplicationRepository) Update(ctx context.Context, app *domain.GuildApplication) error {
+	app.UpdatedAt = time.Now()
+	return MapGormError(r.db.WithContext(ctx).Save(app).Error)
 }

--- a/internal/repository/gorm_guild.go
+++ b/internal/repository/gorm_guild.go
@@ -376,3 +376,27 @@ func (r *guildDefaultSlotRepository) GetByGuildID(ctx context.Context, guildID u
 	}
 	return &slot, nil
 }
+
+func (r *guildDefaultSlotRepository) DeleteByGuildID(ctx context.Context, guildID uuid.UUID) error {
+	res := r.db.WithContext(ctx).Where("guild_id = ?", guildID).Delete(&domain.GuildDefaultSlot{})
+	if res.Error != nil {
+		return MapGormError(res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+func (r *guildDefaultSlotRepository) Upsert(ctx context.Context, slot *domain.GuildDefaultSlot) error {
+	if slot.ID == uuid.Nil {
+		slot.ID = uuid.New()
+	}
+
+	err := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "guild_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"day_of_week", "start_time", "end_time", "updated_at"}),
+	}).Create(slot).Error
+
+	return MapGormError(err)
+}

--- a/internal/repository/gorm_guild.go
+++ b/internal/repository/gorm_guild.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -24,6 +25,45 @@ func (r *gormGuildRepository) GetByID(ctx context.Context, guildID uuid.UUID) (*
 		return nil, MapGormError(err)
 	}
 	return &guild, nil
+}
+
+// 2. 同一個 Transaction 內建立 Guild 與 GuildAttendee(role=master)
+func (r *gormGuildRepository) CreateWithMaster(ctx context.Context, guild *domain.Guild, attendee *domain.GuildAttendee) error {
+	return MapGormError(r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if guild.ID == uuid.Nil {
+			guild.ID = uuid.New()
+		}
+		if err := tx.Create(guild).Error; err != nil {
+			return err
+		}
+
+		attendee.GuildID = guild.ID
+		attendee.Role = domain.GuildAttendeeRoleMaster
+		now := time.Now()
+		if attendee.JoinedAt == nil {
+			attendee.JoinedAt = &now
+		}
+
+		if err := tx.Create(attendee).Error; err != nil {
+			return err
+		}
+
+		return nil
+	}))
+}
+
+// 1. 查詢 Caller 目前建立（或擔任 Master）且尚未退出的公會數量
+func (r *gormGuildRepository) CountMasterGuildsByUserID(ctx context.Context, userID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.db.WithContext(ctx).
+		Model(&domain.GuildAttendee{}).
+		Where("user_id = ? AND role = ? AND left_at IS NULL", userID, domain.GuildAttendeeRoleMaster).
+		Count(&count).Error
+
+	if err != nil {
+		return 0, MapGormError(err)
+	}
+	return count, nil
 }
 
 func (r *gormGuildRepository) Create(ctx context.Context, guild *domain.Guild) error {

--- a/internal/repository/gorm_guild.go
+++ b/internal/repository/gorm_guild.go
@@ -210,6 +210,35 @@ func (r *gormGuildRepository) CreateInviteLinkWithTx(ctx context.Context, guildI
 	})
 }
 
+func (r *gormGuildRepository) Discover(ctx context.Context, page, pageSize int) (*domain.GuildDiscoverResult, error) {
+	var guilds []*domain.Guild
+	var totalCount int64
+
+	db := r.db.WithContext(ctx).Model(&domain.Guild{})
+
+	// Calculate the total count of public guilds
+	if err := db.Count(&totalCount).Error; err != nil {
+		return nil, MapGormError(err)
+	}
+
+	// Calculate the pagination offset
+	offset := (page - 1) * pageSize
+	err := db.Order("updated_at DESC").
+		Offset(offset).
+		Limit(pageSize).
+		Find(&guilds).Error
+	if err != nil {
+		return nil, MapGormError(err)
+	}
+
+	return &domain.GuildDiscoverResult{
+		Items:      guilds,
+		TotalCount: totalCount,
+		Page:       page,
+		PageSize:   pageSize,
+	}, nil
+}
+
 type gormGuildAttendeeRepository struct {
 	db *gorm.DB
 }

--- a/internal/repository/gorm_guild.go
+++ b/internal/repository/gorm_guild.go
@@ -270,3 +270,43 @@ func (r *gormGuildAttendeeRepository) Update(ctx context.Context, attendee *doma
 func (r *gormGuildAttendeeRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	return MapGormError(r.db.WithContext(ctx).Delete(&domain.GuildAttendee{}, "id = ?", id).Error)
 }
+
+type guildApplicationRepository struct {
+	db *gorm.DB
+}
+
+func NewGuildApplicationRepository(db *gorm.DB) domain.GuildApplicationRepository {
+	return &guildApplicationRepository{db: db}
+}
+
+func (r *guildApplicationRepository) Create(ctx context.Context, app *domain.GuildApplication) error {
+	if app.ID == uuid.Nil {
+		app.ID = uuid.New()
+	}
+	return MapGormError(r.db.WithContext(ctx).Create(app).Error)
+}
+
+func (r *guildApplicationRepository) GetPendingByGuildAndUser(ctx context.Context, guildID, userID uuid.UUID) (*domain.GuildApplication, error) {
+	var app domain.GuildApplication
+	err := r.db.WithContext(ctx).
+		Where("guild_id = ? AND user_id = ? AND status = ?", guildID, userID, domain.GuildApplicationStatusPending).
+		First(&app).Error
+
+	if err != nil {
+		return nil, MapGormError(err)
+	}
+	return &app, nil
+}
+
+func (r *guildApplicationRepository) ListPendingByGuildID(ctx context.Context, guildID uuid.UUID) ([]*domain.GuildApplication, error) {
+	var apps []*domain.GuildApplication
+	err := r.db.WithContext(ctx).
+		Where("guild_id = ? AND status = ?", guildID, domain.GuildApplicationStatusPending).
+		Order("created_at ASC").
+		Find(&apps).Error
+
+	if err != nil {
+		return nil, MapGormError(err)
+	}
+	return apps, nil
+}

--- a/internal/repository/gorm_guild.go
+++ b/internal/repository/gorm_guild.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -25,6 +26,19 @@ func (r *gormGuildRepository) GetByID(ctx context.Context, guildID uuid.UUID) (*
 		return nil, MapGormError(err)
 	}
 	return &guild, nil
+}
+
+func (r *gormGuildRepository) CountMasterGuildsByUserID(ctx context.Context, userID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.db.WithContext(ctx).
+		Model(&domain.GuildAttendee{}).
+		Where("user_id = ? AND role = ? AND left_at IS NULL", userID, domain.GuildAttendeeRoleMaster).
+		Count(&count).Error
+
+	if err != nil {
+		return 0, MapGormError(err)
+	}
+	return count, nil
 }
 
 func (r *gormGuildRepository) CreateWithMaster(ctx context.Context, guild *domain.Guild, attendee *domain.GuildAttendee) error {
@@ -51,17 +65,45 @@ func (r *gormGuildRepository) CreateWithMaster(ctx context.Context, guild *domai
 	}))
 }
 
-func (r *gormGuildRepository) CountMasterGuildsByUserID(ctx context.Context, userID uuid.UUID) (int64, error) {
-	var count int64
-	err := r.db.WithContext(ctx).
-		Model(&domain.GuildAttendee{}).
-		Where("user_id = ? AND role = ? AND left_at IS NULL", userID, domain.GuildAttendeeRoleMaster).
-		Count(&count).Error
+func (r *gormGuildRepository) TransferLeader(ctx context.Context, guildID uuid.UUID, newLeaderUserID uuid.UUID) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Check whether the new master is the guild,s member
+		var newMaster domain.GuildAttendee
+		err := tx.Where("guild_id = ? AND user_id = ?", guildID, newLeaderUserID).
+			First(&newMaster).Error
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return domain.ErrNotGuildMember
+			}
+			return err
+		}
 
-	if err != nil {
-		return 0, MapGormError(err)
-	}
-	return count, nil
+		// Downgrade the original master to member.
+		err = tx.Model(&domain.GuildAttendee{}).
+			Where("guild_id = ? AND role = ?", guildID, domain.GuildAttendeeRoleMaster).
+			Update("role", domain.GuildAttendeeRoleMember).Error
+		if err != nil {
+			return err
+		}
+
+		// Promote the new leader to master.
+		err = tx.Model(&domain.GuildAttendee{}).
+			Where("guild_id = ? AND user_id = ?", guildID, newLeaderUserID).
+			Update("role", domain.GuildAttendeeRoleMaster).Error
+		if err != nil {
+			return err
+		}
+
+		// Update the updated_at timestamp
+		err = tx.Model(&domain.Guild{}).
+			Where("id = ?", guildID).
+			Update("updated_at", time.Now()).Error
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
 }
 
 func (r *gormGuildRepository) Create(ctx context.Context, guild *domain.Guild) error {
@@ -87,6 +129,25 @@ func (r *gormGuildRepository) Delete(ctx context.Context, guildID uuid.UUID) err
 		}
 		return MapGormError(tx.Delete(&domain.Guild{}, "id = ?", guildID).Error)
 	})
+}
+
+func (r *gormGuildRepository) GetActiveInviteByGuildID(ctx context.Context, guildID uuid.UUID, now time.Time) (*domain.GuildInvite, error) {
+	var invite domain.GuildInvite
+
+	err := r.db.WithContext(ctx).
+		Where("guild_id = ?", guildID).
+		Where("expires_at IS NULL OR expires_at > ?", now).
+		Order("created_at DESC").
+		First(&invite).Error
+
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return &invite, nil
 }
 
 type gormGuildAttendeeRepository struct {

--- a/internal/repository/gorm_guild.go
+++ b/internal/repository/gorm_guild.go
@@ -27,7 +27,6 @@ func (r *gormGuildRepository) GetByID(ctx context.Context, guildID uuid.UUID) (*
 	return &guild, nil
 }
 
-// 2. 同一個 Transaction 內建立 Guild 與 GuildAttendee(role=master)
 func (r *gormGuildRepository) CreateWithMaster(ctx context.Context, guild *domain.Guild, attendee *domain.GuildAttendee) error {
 	return MapGormError(r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if guild.ID == uuid.Nil {
@@ -52,7 +51,6 @@ func (r *gormGuildRepository) CreateWithMaster(ctx context.Context, guild *domai
 	}))
 }
 
-// 1. 查詢 Caller 目前建立（或擔任 Master）且尚未退出的公會數量
 func (r *gormGuildRepository) CountMasterGuildsByUserID(ctx context.Context, userID uuid.UUID) (int64, error) {
 	var count int64
 	err := r.db.WithContext(ctx).

--- a/internal/repository/gorm_guild.go
+++ b/internal/repository/gorm_guild.go
@@ -356,3 +356,23 @@ func (r *guildApplicationRepository) Update(ctx context.Context, app *domain.Gui
 	app.UpdatedAt = time.Now()
 	return MapGormError(r.db.WithContext(ctx).Save(app).Error)
 }
+
+type guildDefaultSlotRepository struct {
+	db *gorm.DB
+}
+
+func NewGuildDefaultSlotRepository(db *gorm.DB) domain.GuildDefaultSlotRepository {
+	return &guildDefaultSlotRepository{db: db}
+}
+
+func (r *guildDefaultSlotRepository) GetByGuildID(ctx context.Context, guildID uuid.UUID) (*domain.GuildDefaultSlot, error) {
+	var slot domain.GuildDefaultSlot
+	err := r.db.WithContext(ctx).Where("guild_id = ?", guildID).First(&slot).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+	return &slot, nil
+}

--- a/internal/repository/gorm_guild.go
+++ b/internal/repository/gorm_guild.go
@@ -67,7 +67,7 @@ func (r *gormGuildRepository) CreateWithMaster(ctx context.Context, guild *domai
 
 func (r *gormGuildRepository) TransferLeader(ctx context.Context, guildID uuid.UUID, newLeaderUserID uuid.UUID) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Check whether the new master is the guild,s member
+		// Check whether the new master is the guild's member
 		var newMaster domain.GuildAttendee
 		err := tx.Where("guild_id = ? AND user_id = ?", guildID, newLeaderUserID).
 			First(&newMaster).Error
@@ -148,6 +148,25 @@ func (r *gormGuildRepository) GetActiveInviteByGuildID(ctx context.Context, guil
 	}
 
 	return &invite, nil
+}
+
+func (r *gormGuildRepository) CreateInviteLinkWithTx(ctx context.Context, guildID uuid.UUID, newInvite *domain.GuildInvite, now time.Time) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Update the `expires_at` timestamp for all of the guild's currently valid (unexpired) old links to `now`.
+		err := tx.Model(&domain.GuildInvite{}).
+			Where("guild_id = ?", guildID).
+			Where("expires_at IS NULL OR expires_at > ?", now).
+			Update("expires_at", now).Error
+		if err != nil {
+			return err
+		}
+
+		if err := tx.Create(newInvite).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
 }
 
 type gormGuildAttendeeRepository struct {

--- a/internal/repository/gorm_guild.go
+++ b/internal/repository/gorm_guild.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"jpcorrect-backend/internal/domain"
 )
@@ -46,6 +47,23 @@ func (r *gormGuildRepository) CreateWithMaster(ctx context.Context, guild *domai
 		if guild.ID == uuid.Nil {
 			guild.ID = uuid.New()
 		}
+		if attendee.ID == uuid.Nil {
+			attendee.ID = uuid.New()
+		}
+
+		// Enforce the one-master-per-user limit atomically within this
+		// transaction to close the check-then-act race.
+		var masterCount int64
+		err := tx.Model(&domain.GuildAttendee{}).
+			Where("user_id = ? AND role = ? AND left_at IS NULL", attendee.UserID, domain.GuildAttendeeRoleMaster).
+			Count(&masterCount).Error
+		if err != nil {
+			return err
+		}
+		if masterCount >= 1 {
+			return domain.ErrGuildLimitReached
+		}
+
 		if err := tx.Create(guild).Error; err != nil {
 			return err
 		}
@@ -65,16 +83,39 @@ func (r *gormGuildRepository) CreateWithMaster(ctx context.Context, guild *domai
 	}))
 }
 
-func (r *gormGuildRepository) TransferLeader(ctx context.Context, guildID uuid.UUID, newLeaderUserID uuid.UUID) error {
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Check whether the new master is the guild's member
-		var newMaster domain.GuildAttendee
-		err := tx.Where("guild_id = ? AND user_id = ?", guildID, newLeaderUserID).
-			First(&newMaster).Error
-		if err != nil {
+func (r *gormGuildRepository) TransferLeader(ctx context.Context, guildID uuid.UUID, callerID uuid.UUID, newLeaderUserID uuid.UUID) error {
+	return MapGormError(r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Lock the guild row and verify it exists.
+		var guild domain.Guild
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", guildID).First(&guild).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return domain.ErrNotGuildMember
+				return domain.ErrNotFound
 			}
+			return err
+		}
+
+		// Lock the caller's membership row and verify they are the current master.
+		var caller domain.GuildAttendee
+		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("guild_id = ? AND user_id = ? AND left_at IS NULL", guildID, callerID).
+			First(&caller).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return domain.ErrNotGuildMaster
+		}
+		if err != nil {
+			return err
+		}
+		if caller.Role != domain.GuildAttendeeRoleMaster {
+			return domain.ErrNotGuildMaster
+		}
+
+		// Verify the new leader is a current member.
+		var newMaster domain.GuildAttendee
+		if err := tx.Where("guild_id = ? AND user_id = ? AND left_at IS NULL", guildID, newLeaderUserID).
+			First(&newMaster).Error; errors.Is(err, gorm.ErrRecordNotFound) {
+			return domain.ErrNotGuildMember
+		} else if err != nil {
 			return err
 		}
 
@@ -103,7 +144,7 @@ func (r *gormGuildRepository) TransferLeader(ctx context.Context, guildID uuid.U
 		}
 
 		return nil
-	})
+	}))
 }
 
 func (r *gormGuildRepository) Create(ctx context.Context, guild *domain.Guild) error {
@@ -202,6 +243,17 @@ func (r *gormGuildAttendeeRepository) GetByUserID(ctx context.Context, userID uu
 		return nil, MapGormError(err)
 	}
 	return attendees, nil
+}
+
+func (r *gormGuildAttendeeRepository) GetByGuildAndUser(ctx context.Context, guildID uuid.UUID, userID uuid.UUID) (*domain.GuildAttendee, error) {
+	var attendee domain.GuildAttendee
+	err := r.db.WithContext(ctx).
+		Where("guild_id = ? AND user_id = ?", guildID, userID).
+		First(&attendee).Error
+	if err != nil {
+		return nil, MapGormError(err)
+	}
+	return &attendee, nil
 }
 
 func (r *gormGuildAttendeeRepository) Create(ctx context.Context, attendee *domain.GuildAttendee) error {


### PR DESCRIPTION
### 目的
- 3.4
  - 新增公會加入申請功能，包含玩家送出申請、會長/成員查詢pending申請清單，以及會長審核（同意/拒絕）申請的完整 API 
- 3.5
  - 新增公會預設時段的 CRUD 相關 API
- 3.6  
  - 新增公開公會列表 API，以支援公會管理與探索功能

### 方法／實作說明
- 針對 Concurrency 與多表變更處理保證資料一致性
- 採用 API 層 DTO 驗證與 Domain/Repository 邏輯解耦規範

- 主要修改：
  - 3.4
    - domain：擴充 GuildApplication Entity、GuildApplicationStatus Enum 及 Interface
    - repository：實作 GORM 資料存取邏輯，包含 error return 與 transaction 控制
    - api/guild_application.go：新增 GuildApplicationCreateHandler(檢查申請)、GuildApplicationsGetHandler(查詢申請)、GuildApplicationApproveHandler(同意申請) 及 GuildApplicationRejectHandler(拒絕申請)
  - 3.5
    - domain：新增 GuildDefaultSlot Entity以及 Repository Interface
    - repository：實作預設時段之 GetByGuildID、Upsert (搭配 GORM clause.OnConflict) 與 DeleteByGuildID
    - api：新增 GET、Upsert、DELETE 三 Handler。內含 JWT caller 身分判斷與會長權限檢查。
  - 3.6
    - domain：新增 GuildDiscoverResult Struct
    - repository/guild.go：實作 Discover ，支援 updated_at DESC 倒序排序與 SQL Offset 分頁查詢
    - api/guild_discover.go：新增 Request Query DTO，限制 page_size 最大 100 以防止 OOM

- 關鍵實作：
    - 在檢查 Pending 申請以及 Upsert 中，搭配資料庫 (guild_id, user_id) WHERE status = 'pending' 的 Partial Unique Index，避免 Race Condition
    - 審核同意時，於單一 DB Transaction 內同時完成「更新當前申請為 approved」、「新增玩家至 guild_attendees」以及「批量刪除該玩家在其他所有公會的 pending 申請」，確保資料一致性
    - 限制僅有當前公會會長才能執行同意與拒絕操作，並校驗申請單的 GuildID 歸屬與 status == 'pending' 狀態
    - 當預設時段不存在時，GET Handler 回傳 HTTP 200 OK 搭配 {"data": null}；若 Guild 不存在則回傳 404
    - PUT/DELETE 時段 API 加入權限檢查，確保非該公會成員或非 Master 角色無法操作
    - DTO 收錄於 API 層

### 關聯 Issue
- [#35](https://github.com/sessatakuma/jpcorrect-backend/issues/35)

### 附註
- DELETE API 若預設時段原本就不存在，會透過 RowsAffected == 0 轉譯回傳 404 default slot not found

- TODO：
  - [ ] {{描述後續要補上的功能或測試}}